### PR TITLE
Fix Telegram user struct field, refine logging, and disable self-comment check

### DIFF
--- a/pkg/telegram/module/get_discussion.go
+++ b/pkg/telegram/module/get_discussion.go
@@ -3,7 +3,6 @@ package module
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/gotd/td/tg"
 )
@@ -22,9 +21,6 @@ func Modf_getPostDiscussion(
 	channel *tg.Channel,
 	msgID int,
 ) (*Discussion, error) {
-	log.Printf("[LOG] Modf_getPostDiscussion start: channelID=%d  accessHash=%d  msgID=%d",
-		channel.ID, channel.AccessHash, msgID)
-
 	// Запрашиваем информацию об обсуждении
 	discussMsg, err := api.MessagesGetDiscussionMessage(ctx, &tg.MessagesGetDiscussionMessageRequest{
 		Peer: &tg.InputPeerChannel{
@@ -34,7 +30,6 @@ func Modf_getPostDiscussion(
 		MsgID: msgID,
 	})
 	if err != nil {
-		log.Printf("[LOG] MessagesGetDiscussionMessage error: %v", err)
 		return nil, fmt.Errorf("failed to get discussion: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- adapt to UsersUserFull struct by referencing FullUser.ID
- drop unused post variable in comment handling
- reduce noisy logs and add detailed reply diagnostics when scanning posts
- temporarily disable self-comment check to test comment sending

## Testing
- `go build -v ./pkg/telegram`
- `go test ./...` *(fails: malformed import path "atg_go/pkg/telegram/module/unsubscribe_from _channels_group": invalid char ' ')*

------
https://chatgpt.com/codex/tasks/task_e_68907e340ffc83278fee8916c2723a04