### PR TITLE
Запрет повторных комментариев к постам

### DIFF
--- a/pkg/storage/activity.go
+++ b/pkg/storage/activity.go
@@ -8,3 +8,14 @@ func (db *DB) SaveActivity(accountID, channelID, messageID int, activityType str
 	)
 	return err
 }
+
+// HasComment проверяет, оставляла ли учетная запись комментарий к указанному посту.
+// Возвращает true, если запись с activity_type = 'comment' уже существует.
+func (db *DB) HasComment(accountID, messageID int) (bool, error) {
+	var exists bool
+	err := db.Conn.QueryRow(
+		`SELECT EXISTS(SELECT 1 FROM activity WHERE id_account = $1 AND id_message = $2 AND activity_type = 'comment')`,
+		accountID, messageID,
+	).Scan(&exists)
+	return exists, err
+}

--- a/pkg/telegram/module/unsubscribe_from _channels_group/unsubscribe_from _channels_group.go
+++ b/pkg/telegram/module/unsubscribe_from _channels_group/unsubscribe_from _channels_group.go
@@ -1,1 +1,0 @@
-package module


### PR DESCRIPTION
## Summary
- предотвратить повторные комментарии от одного аккаунта к одному посту
- добавить проверку активности в БД и возвращать ID прокомментированного поста
- удалить некорректную директорию с пробелом, из-за которой не собирался проект

## Testing
- `go build ./internal/comments && echo build_ok`
- `go vet ./... && echo vet_ok`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6890fb4a6ebc83278fbbf659401dbb7c