### PR TITLE
Fix Telegram API incompatibilities

### DIFF
--- a/pkg/telegram/comment.go
+++ b/pkg/telegram/comment.go
@@ -194,7 +194,7 @@ func hasRecentCommentByUsers(ctx context.Context, api *tg.Client, channel *tg.Ch
 			continue
 		}
 		if from, ok := msg.FromID.(*tg.PeerUser); ok {
-			if _, exist := userIDs[from.UserID]; exist {
+			if _, exist := userIDs[int(from.UserID)]; exist {
 				return true, nil
 			}
 		}

--- a/pkg/telegram/user.go
+++ b/pkg/telegram/user.go
@@ -23,15 +23,11 @@ func GetUserID(phone string, apiID int, apiHash string) (int, error) {
 	var userID int
 	err = client.Run(ctx, func(ctx context.Context) error {
 		api := tg.NewClient(client)
-		full, err := api.UsersGetFullUser(ctx, &tg.UsersGetFullUserRequest{ID: &tg.InputUserSelf{}})
+		full, err := api.UsersGetFullUser(ctx, &tg.InputUserSelf{})
 		if err != nil {
 			return fmt.Errorf("не удалось получить информацию о пользователе: %w", err)
 		}
-		user, ok := full.User.(*tg.User)
-		if !ok {
-			return fmt.Errorf("некорректный тип пользователя")
-		}
-		userID = user.ID
+		userID = int(full.FullUser.ID)
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- fix user ID map lookup
- update UsersGetFullUser usage to match current gotd API

## Testing
- `go vet ./pkg/telegram`
- `go vet ./...` *(fails: malformed import path "atg_go/pkg/telegram/module/unsubscribe_from _channels_group"*)
- `go build ./pkg/telegram`


------
https://chatgpt.com/codex/tasks/task_e_68913347f3b48327baf13250d50f7cb0