### PR TITLE
feat: add reaction module

### DIFF
--- a/internal/reaction/handler.go
+++ b/internal/reaction/handler.go
@@ -1,1 +1,148 @@
 package reaction
+
+import (
+	"atg_go/pkg/storage"
+	"atg_go/pkg/telegram"
+	"database/sql"
+	"errors"
+	"log"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ReactionHandler отвечает за обработку запросов на массовое добавление реакций.
+type ReactionHandler struct {
+	DB        *storage.DB
+	CommentDB *storage.CommentDB
+}
+
+// NewHandler создаёт новый экземпляр обработчика реакций.
+func NewHandler(db *storage.DB, commentDB *storage.CommentDB) *ReactionHandler {
+	return &ReactionHandler{
+		DB:        db,
+		CommentDB: commentDB,
+	}
+}
+
+// SendReaction добавляет реакции к сообщениям обсуждений во всех каналах.
+func (h *ReactionHandler) SendReaction(c *gin.Context) {
+	var request struct {
+		MsgCount int `json:"msg_count" binding:"required"`
+	}
+
+	log.Printf("[HANDLER] Запуск массовой отправки реакций")
+
+	if err := c.ShouldBindJSON(&request); err != nil {
+		log.Printf("[HANDLER ERROR] Неверный формат запроса: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request format"})
+		return
+	}
+
+	// Получаем все авторизованные аккаунты
+	accounts, err := h.DB.GetAuthorizedAccounts()
+	if err != nil {
+		log.Printf("[HANDLER ERROR] Ошибка получения аккаунтов: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get accounts"})
+		return
+	}
+	if len(accounts) == 0 {
+		log.Printf("[HANDLER WARN] Нет авторизованных аккаунтов")
+		c.JSON(http.StatusNotFound, gin.H{"error": "No authorized accounts available"})
+		return
+	}
+
+	// Счётчики
+	var successCount, errorCount int
+
+	rand.Seed(time.Now().UnixNano())
+
+	// Собираем ID наших аккаунтов, чтобы не реагировать на свои сообщения
+	var userIDs []int
+	for _, acc := range accounts {
+		id, err := telegram.GetUserID(acc.Phone, acc.ApiID, acc.ApiHash)
+		if err != nil {
+			log.Printf("[HANDLER WARN] Не удалось получить ID для %s: %v", acc.Phone, err)
+			continue
+		}
+		userIDs = append(userIDs, id)
+	}
+
+	for i, account := range accounts {
+		// Задержка между аккаунтами
+		if i > 0 {
+			delay := rand.Intn(10) + 6 // 6–15 секунд
+			log.Printf("[HANDLER] Аккаунт %s обработан. Ожидание %d секунд перед следующим...", accounts[i-1].Phone, delay)
+			for remaining := delay; remaining > 0; remaining -= 5 {
+				select {
+				case <-c.Request.Context().Done():
+					log.Printf("[HANDLER WARN] Request cancelled during delay")
+					c.JSON(http.StatusRequestTimeout, gin.H{
+						"status":     "Cancelled during delay",
+						"processed":  i,
+						"successful": successCount,
+						"failed":     errorCount,
+					})
+					return
+				default:
+				}
+				time.Sleep(5 * time.Second)
+			}
+		}
+
+		// Выбор случайного канала
+		channelID, channelURL, err := h.CommentDB.GetRandomChannelWithID()
+		if errors.Is(err, sql.ErrNoRows) {
+			log.Printf("[HANDLER ERROR] Нет доступных каналов: %v", err)
+			c.JSON(http.StatusNotFound, gin.H{"error": "No channels available"})
+			return
+		}
+		if err != nil {
+			log.Printf("[HANDLER ERROR] Ошибка выбора канала для %s: %v", account.Phone, err)
+			errorCount++
+			continue
+		}
+		log.Printf("[HANDLER INFO] Выбран канал для %s: %s", account.Phone, channelURL)
+
+		msgID, err := telegram.SendReaction(
+			account.Phone,
+			channelURL,
+			account.ApiID,
+			account.ApiHash,
+			request.MsgCount,
+			userIDs,
+		)
+		if err != nil {
+			log.Printf("[HANDLER ERROR] Ошибка отправки реакции для %s: %v", account.Phone, err)
+			errorCount++
+			continue
+		}
+		if msgID == 0 {
+			log.Printf("[HANDLER INFO] Не найдено подходящих сообщений для аккаунта %s", account.Phone)
+			continue
+		}
+
+		h.recordReaction(account.ID, channelID, msgID)
+
+		successCount++
+		log.Printf("[HANDLER DEBUG] Успех для аккаунта: %s", account.Phone)
+	}
+
+	result := gin.H{
+		"status":         "Processing complete",
+		"total_accounts": len(accounts),
+		"successful":     successCount,
+		"failed":         errorCount,
+	}
+	log.Printf("[HANDLER INFO] Итог: %+v", result)
+	c.JSON(http.StatusOK, result)
+}
+
+// recordReaction сохраняет информацию об активности в базе.
+func (h *ReactionHandler) recordReaction(accountID, channelID, messageID int) {
+	if err := h.DB.SaveActivity(accountID, channelID, messageID, "reaction"); err != nil {
+		log.Printf("Не удалось сохранить активность для аккаунта %d: %v", accountID, err)
+	}
+}

--- a/internal/reaction/routes.go
+++ b/internal/reaction/routes.go
@@ -1,7 +1,15 @@
 package reaction
 
-// func SetupRoutes(r *gin.RouterGroup, db *storage.DB, commentDB *storage.CommentDB) {
-// 	handler := NewHandler(db, commentDB)
-// 	r.POST("/send", handler.SendReaction)
-// 	log.Printf("[ROUTER] Reaction routes registered")
-// }
+import (
+	"log"
+
+	"atg_go/pkg/storage"
+	"github.com/gin-gonic/gin"
+)
+
+// SetupRoutes регистрирует маршруты для работы с реакциями.
+func SetupRoutes(r *gin.RouterGroup, db *storage.DB, commentDB *storage.CommentDB) {
+	handler := NewHandler(db, commentDB)
+	r.POST("/send", handler.SendReaction)
+	log.Printf("[ROUTER] Reaction routes registered")
+}

--- a/main.go
+++ b/main.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"atg_go/internal/auth"
-	"atg_go/internal/comments"
-	module "atg_go/internal/module"
-	"atg_go/pkg/storage"
-	"database/sql"
-	"log"
-	"os"
+        "atg_go/internal/auth"
+        "atg_go/internal/comments"
+        reaction "atg_go/internal/reaction"
+        module "atg_go/internal/module"
+        "atg_go/pkg/storage"
+        "database/sql"
+        "log"
+        "os"
 
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
@@ -61,9 +62,9 @@ func setupRouter(db *storage.DB, commentDB *storage.CommentDB) *gin.Engine {
 	commentGroup := r.Group("/comment")
 	comments.SetupRoutes(commentGroup, db, commentDB) // Передаем оба хранилища
 
-	// Группа роутов для реакций на чужие комментарии
-	// reactionGroup := r.Group("/reaction")
-	// reaction.SetupRoutes(reactionGroup, db, commentDB)
+        // Группа роутов для реакций на чужие комментарии
+        reactionGroup := r.Group("/reaction")
+        reaction.SetupRoutes(reactionGroup, db, commentDB)
 
 	// Группа роутов для telegram-модуля
 	moduleGroup := r.Group("/module")
@@ -77,9 +78,10 @@ func setupRouter(db *storage.DB, commentDB *storage.CommentDB) *gin.Engine {
 	// Логирование зарегистрированных роутов
 	log.Printf("[ROUTER] Routes initialized:")
 	log.Printf("[ROUTER] POST /auth/CreateAccount")
-	log.Printf("[ROUTER] POST /comment/send")
-	log.Printf("[ROUTER] POST /module/dispatcher_activity")
-	log.Printf("[ROUTER] GET /health")
+        log.Printf("[ROUTER] POST /comment/send")
+        log.Printf("[ROUTER] POST /reaction/send")
+        log.Printf("[ROUTER] POST /module/dispatcher_activity")
+        log.Printf("[ROUTER] GET /health")
 
 	return r
 }

--- a/pkg/telegram/module/get_allowed_reactions.go
+++ b/pkg/telegram/module/get_allowed_reactions.go
@@ -1,0 +1,66 @@
+package module
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gotd/td/tg"
+)
+
+// GetAllowedReactions возвращает список эмодзи, которые разрешены
+// для использования в указанном канале или обсуждении.
+// Если канал позволяет любые стандартные реакции, возвращается исходный
+// список base. Если разрешённых реакций нет, возвращается пустой список.
+func GetAllowedReactions(
+	ctx context.Context,
+	api *tg.Client,
+	channel *tg.Channel,
+	base []string,
+) ([]string, error) {
+	full, err := api.ChannelsGetFullChannel(ctx, &tg.InputChannel{
+		ChannelID:  channel.ID,
+		AccessHash: channel.AccessHash,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get full channel: %w", err)
+	}
+
+	fullChat, ok := full.GetFullChat().(*tg.ChannelFull)
+	if !ok {
+		// Не удалось получить полную информацию о канале
+		return nil, fmt.Errorf("unexpected chat full type")
+	}
+
+	reactions, ok := fullChat.GetAvailableReactions()
+	if !ok || reactions == nil {
+		// Если нет информации — считаем, что разрешены все реакции из base
+		return base, nil
+	}
+
+	switch r := reactions.(type) {
+	case *tg.ChatReactionsAll:
+		// Разрешены все стандартные реакции — используем наш базовый список
+		return base, nil
+	case *tg.ChatReactionsNone:
+		// В канале отключены реакции
+		return []string{}, nil
+	case *tg.ChatReactionsSome:
+		// Составляем пересечение разрешённых реакций и нашего базового списка
+		allowed := make(map[string]struct{})
+		for _, rc := range r.Reactions {
+			if emoji, ok := rc.(*tg.ReactionEmoji); ok {
+				allowed[emoji.Emoticon] = struct{}{}
+			}
+		}
+		var result []string
+		for _, e := range base {
+			if _, ok := allowed[e]; ok {
+				result = append(result, e)
+			}
+		}
+		return result, nil
+	default:
+		// Неизвестный тип — возвращаем базовый список
+		return base, nil
+	}
+}

--- a/pkg/telegram/module/get_replies.go
+++ b/pkg/telegram/module/get_replies.go
@@ -1,0 +1,38 @@
+package module
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gotd/td/tg"
+)
+
+// GetDiscussionReplies возвращает последние сообщения в обсуждении поста.
+func GetDiscussionReplies(ctx context.Context, api *tg.Client, chat *tg.Channel, msgID, limit int) ([]*tg.Message, error) {
+	res, err := api.MessagesGetReplies(ctx, &tg.MessagesGetRepliesRequest{
+		Peer:  &tg.InputPeerChannel{ChannelID: chat.ID, AccessHash: chat.AccessHash},
+		MsgID: msgID,
+		Limit: limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	msgs, ok := res.(*tg.MessagesChannelMessages)
+	if !ok {
+		return nil, fmt.Errorf("unexpected messages type")
+	}
+
+	var valid []*tg.Message
+	for _, m := range msgs.Messages {
+		if msg, ok := m.(*tg.Message); ok {
+			valid = append(valid, msg)
+		}
+	}
+
+	if len(valid) == 0 {
+		return nil, fmt.Errorf("no valid messages")
+	}
+
+	return valid, nil
+}

--- a/pkg/telegram/module/unsubscribe_from _channels_group/unsubscribe_from _channels_group.go
+++ b/pkg/telegram/module/unsubscribe_from _channels_group/unsubscribe_from _channels_group.go
@@ -1,1 +1,0 @@
-package module

--- a/pkg/telegram/reaction.go
+++ b/pkg/telegram/reaction.go
@@ -1,3 +1,155 @@
 package telegram
 
-//
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/rand"
+	"time"
+
+	module "atg_go/pkg/telegram/module"
+
+	"github.com/gotd/td/tg"
+)
+
+// SendReaction выполняет добавление реакции к последнему сообщению обсуждения
+// канала, у которого отсутствуют реакции. Возвращает ID сообщения, к которому
+// была добавлена реакция.
+func SendReaction(phone, channelURL string, apiID int, apiHash string, msgCount int, userIDs []int) (int, error) {
+	log.Printf("[START] Отправка реакции в канал %s от имени %s", channelURL, phone)
+
+	username, err := module.Modf_ExtractUsername(channelURL)
+	if err != nil {
+		return 0, fmt.Errorf("не удалось извлечь имя пользователя: %w", err)
+	}
+
+	client, err := module.Modf_AccountInitialization(apiID, apiHash, phone)
+	if err != nil {
+		return 0, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	var reactedMsgID int
+
+	err = client.Run(ctx, func(ctx context.Context) error {
+		api := tg.NewClient(client)
+
+		resolved, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: username})
+		if err != nil {
+			return fmt.Errorf("не удалось распознать канал: %w", err)
+		}
+
+		channel, err := module.Modf_FindChannel(resolved.GetChats())
+		if err != nil {
+			return err
+		}
+
+		if errJoin := module.Modf_JoinChannel(ctx, api, channel); errJoin != nil {
+			log.Printf("[ERROR] Не удалось вступить в канал: ID=%d Ошибка=%v", channel.ID, errJoin)
+		}
+
+		posts, err := module.GetChannelPosts(ctx, api, channel, 1)
+		if err != nil {
+			return fmt.Errorf("не удалось получить посты канала: %w", err)
+		}
+
+		discussion, err := module.Modf_getPostDiscussion(ctx, api, channel, posts[0].ID)
+		if err != nil {
+			return fmt.Errorf("не удалось получить обсуждение: %w", err)
+		}
+
+		if errJoin := module.Modf_JoinChannel(ctx, api, discussion.Chat); errJoin != nil {
+			log.Printf("[ERROR] Не удалось вступить в чат обсуждения: ID=%d Ошибка=%v", discussion.Chat.ID, errJoin)
+		}
+
+		// Получаем список разрешённых реакций
+		allowedReactions, err := module.GetAllowedReactions(ctx, api, discussion.Chat, reactionList)
+		if err != nil {
+			return fmt.Errorf("не удалось получить доступные реакции: %w", err)
+		}
+		if len(allowedReactions) == 0 {
+			return fmt.Errorf("нет доступных реакций в чате")
+		}
+
+		// Запрашиваем последние сообщения из обсуждения поста
+		messages, err := module.GetDiscussionReplies(ctx, api, discussion.Chat, discussion.PostMessage.ID, msgCount)
+		if err != nil {
+			return fmt.Errorf("не удалось получить сообщения обсуждения: %w", err)
+		}
+
+		idSet := make(map[int]struct{}, len(userIDs))
+		for _, id := range userIDs {
+			idSet[id] = struct{}{}
+		}
+
+		var lastUserMsg *tg.Message
+
+		// Идём от последних сообщений к более ранним
+		for i := len(messages) - 1; i >= 0; i-- {
+			msg := messages[i]
+			// Пропускаем сообщения без автора-пользователя (например, пост канала или служебные сообщения)
+			from, ok := msg.FromID.(*tg.PeerUser)
+			if !ok {
+				continue
+			}
+			// Пропускаем сообщения наших аккаунтов
+			if _, exists := idSet[int(from.UserID)]; exists {
+				continue
+			}
+
+			// Сохраняем первое подходящее сообщение для fallback
+			if lastUserMsg == nil {
+				lastUserMsg = msg
+			}
+
+			// Отправляем реакцию, если у сообщения нет других реакций
+			if len(msg.Reactions.Results) == 0 {
+				reaction := getRandomReaction(allowedReactions)
+				_, err := api.MessagesSendReaction(ctx, &tg.MessagesSendReactionRequest{
+					Peer:        &tg.InputPeerChannel{ChannelID: discussion.Chat.ID, AccessHash: discussion.Chat.AccessHash},
+					MsgID:       msg.ID,
+					Reaction:    []tg.ReactionClass{&tg.ReactionEmoji{Emoticon: reaction}},
+					AddToRecent: true,
+				})
+				if err != nil {
+					return fmt.Errorf("не удалось отправить реакцию: %w", err)
+				}
+				reactedMsgID = msg.ID
+				log.Printf("Реакция %s успешно отправлена", reaction)
+				return nil
+			}
+		}
+
+		// Если все сообщения уже имеют реакции, реагируем на первое подходящее
+		if lastUserMsg != nil {
+			reaction := getRandomReaction(allowedReactions)
+			_, err := api.MessagesSendReaction(ctx, &tg.MessagesSendReactionRequest{
+				Peer:        &tg.InputPeerChannel{ChannelID: discussion.Chat.ID, AccessHash: discussion.Chat.AccessHash},
+				MsgID:       lastUserMsg.ID,
+				Reaction:    []tg.ReactionClass{&tg.ReactionEmoji{Emoticon: reaction}},
+				AddToRecent: true,
+			})
+			if err != nil {
+				return fmt.Errorf("не удалось отправить реакцию: %w", err)
+			}
+			reactedMsgID = lastUserMsg.ID
+			log.Printf("Реакция %s успешно отправлена", reaction)
+			return nil
+		}
+
+		log.Printf("[INFO] Не найдено подходящих сообщений в обсуждении")
+		return nil
+	})
+
+	return reactedMsgID, err
+}
+
+var reactionList = []string{"❤️", "😂"}
+
+// getRandomReaction возвращает случайную реакцию из переданного списка.
+func getRandomReaction(reactions []string) string {
+	rand.Seed(time.Now().UnixNano())
+	return reactions[rand.Intn(len(reactions))]
+}


### PR DESCRIPTION
## Summary
- add reaction handler and routes
- implement Telegram reaction logic for discussions
- register reaction routes and remove invalid module directory
- ensure reactions respect channel's allowed set
- react only to discussion comments and skip channel posts
- fall back to reacting to the latest user message even if all messages already have reactions
- fetch discussion replies when selecting messages for reactions

## Testing
- `go test ./...` (command produced no output and was interrupted)
- `go test ./internal/reaction` (command produced no output and was interrupted)
- `go test ./pkg/telegram` (command produced no output and was interrupted)


------
https://chatgpt.com/codex/tasks/task_e_6891db88b7748327b77adf0e8a49de95