### PR TITLE
feat: react to latest discussion message

### DIFF
--- a/internal/reaction/handler.go
+++ b/internal/reaction/handler.go
@@ -59,17 +59,6 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 
 	rand.Seed(time.Now().UnixNano())
 
-	// Собираем ID наших аккаунтов, чтобы не реагировать на свои сообщения
-	var userIDs []int
-	for _, acc := range accounts {
-		id, err := telegram.GetUserID(acc.Phone, acc.ApiID, acc.ApiHash)
-		if err != nil {
-			log.Printf("[HANDLER WARN] Не удалось получить ID для %s: %v", acc.Phone, err)
-			continue
-		}
-		userIDs = append(userIDs, id)
-	}
-
 	for i, account := range accounts {
 		// Задержка между аккаунтами
 		if i > 0 {
@@ -112,7 +101,6 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 			account.ApiID,
 			account.ApiHash,
 			request.MsgCount,
-			userIDs,
 		)
 		if err != nil {
 			log.Printf("[HANDLER ERROR] Ошибка отправки реакции для %s: %v", account.Phone, err)

--- a/pkg/telegram/reaction_test.go
+++ b/pkg/telegram/reaction_test.go
@@ -1,0 +1,41 @@
+package telegram
+
+import (
+	"testing"
+
+	"github.com/gotd/td/tg"
+)
+
+// TestSelectTargetMessage_LastMessage проверяет, что выбирается последнее сообщение.
+func TestSelectTargetMessage_LastMessage(t *testing.T) {
+	msgs := []*tg.Message{{ID: 1}, {ID: 2}, {ID: 3}}
+	msg, err := selectTargetMessage(msgs)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+	if msg.ID != 3 {
+		t.Fatalf("ожидался ID 3, получено %d", msg.ID)
+	}
+}
+
+// TestSelectTargetMessage_Empty проверяет, что при отсутствии сообщений возвращается ошибка.
+func TestSelectTargetMessage_Empty(t *testing.T) {
+	if _, err := selectTargetMessage([]*tg.Message{}); err == nil {
+		t.Fatalf("ожидалась ошибка, но её нет")
+	}
+}
+
+// TestSelectTargetMessage_IgnoresReactions убеждается, что наличие реакций не влияет на выбор.
+func TestSelectTargetMessage_IgnoresReactions(t *testing.T) {
+	msgs := []*tg.Message{
+		{ID: 1},
+		{ID: 2, Reactions: &tg.MessageReactions{Results: []tg.ReactionCount{{Reaction: &tg.ReactionEmoji{Emoticon: "❤️"}, Count: 1}}}},
+	}
+	msg, err := selectTargetMessage(msgs)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+	if msg.ID != 2 {
+		t.Fatalf("ожидался ID 2, получено %d", msg.ID)
+	}
+}


### PR DESCRIPTION
## Summary
- always react to the most recent discussion message
- simplify handler by removing user ID filtering
- add unit tests covering last-message selection

## Testing
- `go test ./...` *(hung, interrupted)*
- `go test ./pkg/telegram -run TestSelectTargetMessage -count=1` *(hung, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68922a84bf0c832798c00b761a442677