### PR TITLE
Use ChannelsGetChannels for discussion chat retrieval

### DIFF
--- a/pkg/telegram/reaction_test.go
+++ b/pkg/telegram/reaction_test.go
@@ -29,7 +29,7 @@ func TestSelectTargetMessage_Empty(t *testing.T) {
 func TestSelectTargetMessage_IgnoresReactions(t *testing.T) {
 	msgs := []*tg.Message{
 		{ID: 1},
-		{ID: 2, Reactions: &tg.MessageReactions{Results: []tg.ReactionCount{{Reaction: &tg.ReactionEmoji{Emoticon: "❤️"}, Count: 1}}}},
+		{ID: 2, Reactions: tg.MessageReactions{Results: []tg.ReactionCount{{Reaction: &tg.ReactionEmoji{Emoticon: "❤️"}, Count: 1}}}},
 	}
 	msg, err := selectTargetMessage(msgs)
 	if err != nil {


### PR DESCRIPTION
## Summary
- extract discussion channel from `full.GetChats` to obtain access hash
- query channel via `ChannelsGetChannels` and join if not a participant
- retry sending reaction with alternative emojis when Telegram rejects a reaction

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68927c13e1348327a94ee066e9078144