### PR TITLE
Use ChannelsGetChannels for discussion chat retrieval

### DIFF
--- a/pkg/telegram/reaction.go
+++ b/pkg/telegram/reaction.go
@@ -87,18 +87,34 @@ func SendReaction(phone, channelURL string, apiID int, apiHash string, msgCount 
 		}
 		log.Printf("[DEBUG] Целевое сообщение ID=%d", targetMsg.ID)
 
-		// Ставим реакцию на найденное сообщение
-		reaction := getRandomReaction(allowedReactions)
+		// Выбираем реакцию: случайную из нашего списка, но если она не разрешена,
+		// используем первую разрешённую админами обсуждения.
+		reaction := pickReaction(reactionList, allowedReactions)
 		log.Printf("[DEBUG] Отправляем реакцию %s", reaction)
-		_, err = api.MessagesSendReaction(ctx, &tg.MessagesSendReactionRequest{
-			Peer:        &tg.InputPeerChannel{ChannelID: discussionChat.ID, AccessHash: discussionChat.AccessHash},
-			MsgID:       targetMsg.ID,
-			Reaction:    []tg.ReactionClass{&tg.ReactionEmoji{Emoticon: reaction}},
-			AddToRecent: true,
-		})
-		if err != nil {
-			return fmt.Errorf("не удалось отправить реакцию: %w", err)
+
+		send := func(r string) error {
+			_, err = api.MessagesSendReaction(ctx, &tg.MessagesSendReactionRequest{
+				Peer:        &tg.InputPeerChannel{ChannelID: discussionChat.ID, AccessHash: discussionChat.AccessHash},
+				MsgID:       targetMsg.ID,
+				Reaction:    []tg.ReactionClass{&tg.ReactionEmoji{Emoticon: r}},
+				AddToRecent: true,
+			})
+			return err
 		}
+
+		if errSend := send(reaction); errSend != nil {
+			if tg.IsReactionInvalid(errSend) && reaction != allowedReactions[0] {
+				log.Printf("[WARN] Реакция %s недопустима: %v", reaction, errSend)
+				reaction = allowedReactions[0]
+				log.Printf("[DEBUG] Отправляем реакцию %s", reaction)
+				if errSend = send(reaction); errSend != nil {
+					return fmt.Errorf("не удалось отправить реакцию: %w", errSend)
+				}
+			} else {
+				return fmt.Errorf("не удалось отправить реакцию: %w", errSend)
+			}
+		}
+
 		reactedMsgID = targetMsg.ID
 		log.Printf("Реакция %s успешно отправлена", reaction)
 		return nil
@@ -107,20 +123,40 @@ func SendReaction(phone, channelURL string, apiID int, apiHash string, msgCount 
 	return reactedMsgID, err
 }
 
-var reactionList = []string{"❤️", "😂"}
+var reactionList = []string{"❤️", "👍"}
+
+var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 // getRandomReaction возвращает случайную реакцию из переданного списка.
 func getRandomReaction(reactions []string) string {
-	rand.Seed(time.Now().UnixNano())
-	return reactions[rand.Intn(len(reactions))]
+	return reactions[rnd.Intn(len(reactions))]
 }
 
-// selectTargetMessage выбирает сообщение для отправки реакции.
-// Всегда возвращает последнее сообщение из списка, если он не пуст.
-// В противном случае возвращает ошибку.
+// pickReaction выбирает случайную реакцию из base, если она разрешена.
+// Если случайно выбранная реакция запрещена, возвращает первую из allowed.
+func pickReaction(base, allowed []string) string {
+	r := getRandomReaction(base)
+	for _, a := range allowed {
+		if r == a {
+			return r
+		}
+	}
+	return allowed[0]
+}
+
+// selectTargetMessage выбирает самое новое сообщение без реакций.
+// MessagesGetHistory возвращает сообщения от новых к старым,
+// поэтому проходим по списку и ищем первое сообщение,
+// у которого отсутствуют реакции. Если все сообщения уже
+// содержат реакции, возвращаем ошибку.
 func selectTargetMessage(messages []*tg.Message) (*tg.Message, error) {
 	if len(messages) == 0 {
 		return nil, fmt.Errorf("нет сообщений для реакции")
 	}
-	return messages[len(messages)-1], nil
+	for _, m := range messages {
+		if len(m.Reactions.Results) == 0 {
+			return m, nil
+		}
+	}
+	return nil, fmt.Errorf("подходящее сообщение без реакций не найдено")
 }

--- a/pkg/telegram/reaction_test.go
+++ b/pkg/telegram/reaction_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/gotd/td/tg"
 )
 
-// TestSelectTargetMessage_LastMessage проверяет, что выбирается последнее сообщение.
-func TestSelectTargetMessage_LastMessage(t *testing.T) {
-	msgs := []*tg.Message{{ID: 1}, {ID: 2}, {ID: 3}}
+// TestSelectTargetMessage_NewestMessage проверяет, что выбирается самое новое сообщение без реакций.
+func TestSelectTargetMessage_NewestMessage(t *testing.T) {
+	msgs := []*tg.Message{{ID: 3}, {ID: 2}, {ID: 1}}
 	msg, err := selectTargetMessage(msgs)
 	if err != nil {
 		t.Fatalf("неожиданная ошибка: %v", err)
@@ -25,11 +25,12 @@ func TestSelectTargetMessage_Empty(t *testing.T) {
 	}
 }
 
-// TestSelectTargetMessage_IgnoresReactions убеждается, что наличие реакций не влияет на выбор.
-func TestSelectTargetMessage_IgnoresReactions(t *testing.T) {
+// TestSelectTargetMessage_SkipReactions убеждается, что сообщения с реакциями пропускаются.
+func TestSelectTargetMessage_SkipReactions(t *testing.T) {
 	msgs := []*tg.Message{
+		{ID: 3, Reactions: tg.MessageReactions{Results: []tg.ReactionCount{{Reaction: &tg.ReactionEmoji{Emoticon: "❤️"}, Count: 1}}}},
+		{ID: 2},
 		{ID: 1},
-		{ID: 2, Reactions: &tg.MessageReactions{Results: []tg.ReactionCount{{Reaction: &tg.ReactionEmoji{Emoticon: "❤️"}, Count: 1}}}},
 	}
 	msg, err := selectTargetMessage(msgs)
 	if err != nil {
@@ -37,5 +38,49 @@ func TestSelectTargetMessage_IgnoresReactions(t *testing.T) {
 	}
 	if msg.ID != 2 {
 		t.Fatalf("ожидался ID 2, получено %d", msg.ID)
+	}
+}
+
+// TestSelectTargetMessage_AllWithReactions проверяет, что возвращается ошибка, если все сообщения уже с реакциями.
+func TestSelectTargetMessage_AllWithReactions(t *testing.T) {
+	msgs := []*tg.Message{
+		{ID: 2, Reactions: tg.MessageReactions{Results: []tg.ReactionCount{{Reaction: &tg.ReactionEmoji{Emoticon: "❤️"}, Count: 1}}}},
+		{ID: 1, Reactions: tg.MessageReactions{Results: []tg.ReactionCount{{Reaction: &tg.ReactionEmoji{Emoticon: "😂"}, Count: 1}}}},
+	}
+	if _, err := selectTargetMessage(msgs); err == nil {
+		t.Fatalf("ожидалась ошибка, но её нет")
+	}
+}
+
+// TestPickReactionFallback проверяет, что при выборе запрещённой реакции
+// возвращается первая разрешённая.
+func TestPickReactionFallback(t *testing.T) {
+	rnd.Seed(1)
+	allowed := []string{"❤️"}
+	base := []string{"👍"}
+	r := pickReaction(base, allowed)
+	if r != "❤️" {
+		t.Fatalf("ожидалась реакция ❤️, получено %s", r)
+	}
+}
+
+// TestPickReactionAllowed убеждается, что разрешённая реакция может быть выбрана.
+func TestPickReactionAllowed(t *testing.T) {
+	rnd.Seed(2)
+	allowed := []string{"❤️", "👍"}
+	base := []string{"❤️", "👍"}
+	r := pickReaction(base, allowed)
+	if r != "👍" && r != "❤️" {
+		t.Fatalf("неожиданная реакция: %s", r)
+	}
+	// Дополнительно проверяем, что выбранная реакция входит в список allowed.
+	ok := false
+	for _, a := range allowed {
+		if r == a {
+			ok = true
+		}
+	}
+	if !ok {
+		t.Fatalf("выбрана реакция, не разрешённая администраторами: %s", r)
 	}
 }


### PR DESCRIPTION
## Summary
- extract discussion channel from `full.GetChats` to obtain access hash
- query channel via `ChannelsGetChannels` and join if not a participant
- retry sending reaction with alternative emojis when Telegram rejects a reaction
- choose the newest discussion message without reactions before reacting
- randomize reaction choice between heart and thumbs-up and fall back to the first admin-permitted emoji

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68927c13e1348327a94ee066e9078144