### PR TITLE
Use ChannelsGetChannels for discussion chat retrieval

### DIFF
--- a/internal/reaction/handler.go
+++ b/internal/reaction/handler.go
@@ -82,7 +82,7 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 		}
 
 		// Выбор случайного канала
-		channelID, channelURL, err := h.CommentDB.GetRandomChannelWithID()
+		channelURL, err := h.CommentDB.GetRandomChannel()
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Printf("[HANDLER ERROR] Нет доступных каналов: %v", err)
 			c.JSON(http.StatusNotFound, gin.H{"error": "No channels available"})
@@ -95,7 +95,7 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 		}
 		log.Printf("[HANDLER INFO] Выбран канал для %s: %s", account.Phone, channelURL)
 
-		msgID, err := telegram.SendReaction(
+		msgID, channelID, err := telegram.SendReaction(
 			account.Phone,
 			channelURL,
 			account.ApiID,
@@ -128,9 +128,9 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
-// recordReaction сохраняет информацию об активности в базе.
+// recordReaction сохраняет информацию о поставленной реакции в таблице activity.
 func (h *ReactionHandler) recordReaction(accountID, channelID, messageID int) {
-	if err := h.DB.SaveActivity(accountID, channelID, messageID, "reaction"); err != nil {
+	if err := h.DB.SaveReaction(accountID, channelID, messageID); err != nil {
 		log.Printf("Не удалось сохранить активность для аккаунта %d: %v", accountID, err)
 	}
 }

--- a/pkg/storage/activity.go
+++ b/pkg/storage/activity.go
@@ -1,5 +1,8 @@
 package storage
 
+// ActivityTypeReaction — значение поля activity_type для реакций.
+const ActivityTypeReaction = "reaction"
+
 // SaveActivity persists an account action in the activity table.
 func (db *DB) SaveActivity(accountID, channelID, messageID int, activityType string) error {
 	_, err := db.Conn.Exec(
@@ -7,6 +10,11 @@ func (db *DB) SaveActivity(accountID, channelID, messageID int, activityType str
 		accountID, channelID, messageID, activityType,
 	)
 	return err
+}
+
+// SaveReaction сохраняет информацию о реакции в таблице activity.
+func (db *DB) SaveReaction(accountID, channelID, messageID int) error {
+	return db.SaveActivity(accountID, channelID, messageID, ActivityTypeReaction)
 }
 
 // HasComment проверяет, оставляла ли учетная запись комментарий к указанному посту.

--- a/pkg/telegram/reaction_test.go
+++ b/pkg/telegram/reaction_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/gotd/td/tg"
 )
 
-// TestSelectTargetMessage_LastMessage проверяет, что выбирается последнее сообщение.
-func TestSelectTargetMessage_LastMessage(t *testing.T) {
-	msgs := []*tg.Message{{ID: 1}, {ID: 2}, {ID: 3}}
+// TestSelectTargetMessage_NewestMessage проверяет, что выбирается самое новое сообщение без реакций.
+func TestSelectTargetMessage_NewestMessage(t *testing.T) {
+	msgs := []*tg.Message{{ID: 3}, {ID: 2}, {ID: 1}}
 	msg, err := selectTargetMessage(msgs)
 	if err != nil {
 		t.Fatalf("неожиданная ошибка: %v", err)
@@ -25,11 +25,12 @@ func TestSelectTargetMessage_Empty(t *testing.T) {
 	}
 }
 
-// TestSelectTargetMessage_IgnoresReactions убеждается, что наличие реакций не влияет на выбор.
-func TestSelectTargetMessage_IgnoresReactions(t *testing.T) {
+// TestSelectTargetMessage_SkipReactions убеждается, что сообщения с реакциями пропускаются.
+func TestSelectTargetMessage_SkipReactions(t *testing.T) {
 	msgs := []*tg.Message{
+		{ID: 3, Reactions: tg.MessageReactions{Results: []tg.ReactionCount{{Reaction: &tg.ReactionEmoji{Emoticon: "❤️"}, Count: 1}}}},
+		{ID: 2},
 		{ID: 1},
-		{ID: 2, Reactions: &tg.MessageReactions{Results: []tg.ReactionCount{{Reaction: &tg.ReactionEmoji{Emoticon: "❤️"}, Count: 1}}}},
 	}
 	msg, err := selectTargetMessage(msgs)
 	if err != nil {
@@ -37,5 +38,49 @@ func TestSelectTargetMessage_IgnoresReactions(t *testing.T) {
 	}
 	if msg.ID != 2 {
 		t.Fatalf("ожидался ID 2, получено %d", msg.ID)
+	}
+}
+
+// TestSelectTargetMessage_AllWithReactions проверяет, что возвращается ошибка, если все сообщения уже с реакциями.
+func TestSelectTargetMessage_AllWithReactions(t *testing.T) {
+	msgs := []*tg.Message{
+		{ID: 2, Reactions: tg.MessageReactions{Results: []tg.ReactionCount{{Reaction: &tg.ReactionEmoji{Emoticon: "❤️"}, Count: 1}}}},
+		{ID: 1, Reactions: tg.MessageReactions{Results: []tg.ReactionCount{{Reaction: &tg.ReactionEmoji{Emoticon: "😂"}, Count: 1}}}},
+	}
+	if _, err := selectTargetMessage(msgs); err == nil {
+		t.Fatalf("ожидалась ошибка, но её нет")
+	}
+}
+
+// TestPickReactionFallback проверяет, что при выборе запрещённой реакции
+// возвращается первая разрешённая.
+func TestPickReactionFallback(t *testing.T) {
+	rnd.Seed(1)
+	allowed := []string{"❤️"}
+	base := []string{"👍"}
+	r := pickReaction(base, allowed)
+	if r != "❤️" {
+		t.Fatalf("ожидалась реакция ❤️, получено %s", r)
+	}
+}
+
+// TestPickReactionAllowed убеждается, что разрешённая реакция может быть выбрана.
+func TestPickReactionAllowed(t *testing.T) {
+	rnd.Seed(2)
+	allowed := []string{"❤️", "👍"}
+	base := []string{"❤️", "👍"}
+	r := pickReaction(base, allowed)
+	if r != "👍" && r != "❤️" {
+		t.Fatalf("неожиданная реакция: %s", r)
+	}
+	// Дополнительно проверяем, что выбранная реакция входит в список allowed.
+	ok := false
+	for _, a := range allowed {
+		if r == a {
+			ok = true
+		}
+	}
+	if !ok {
+		t.Fatalf("выбрана реакция, не разрешённая администраторами: %s", r)
 	}
 }


### PR DESCRIPTION
## Summary
- extract discussion channel from `full.GetChats` to obtain access hash
- query channel via `ChannelsGetChannels` and join if not a participant
- retry sending reaction with alternative emojis when Telegram rejects a reaction
- choose the newest discussion message without reactions before reacting
- randomize reaction choice between heart and thumbs-up and fall back to the first admin-permitted emoji
- record each successful reaction in the `activity` table
- persist actual Telegram channel IDs for recorded reactions and comments

## Testing
- `go test ./...` *(hangs; terminated)*
- `go test ./pkg/telegram -run TestPickReactionFallback -count=1` *(hangs; terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68927c13e1348327a94ee066e9078144