### PR TITLE
Fix activity save for comments

### DIFF
--- a/pkg/storage/activity.go
+++ b/pkg/storage/activity.go
@@ -5,6 +5,9 @@ import "time"
 // ActivityTypeReaction — значение поля activity_type для реакций.
 const ActivityTypeReaction = "reaction"
 
+// ActivityTypeComment — значение поля activity_type для комментариев.
+const ActivityTypeComment = "comment"
+
 // SaveActivity сохраняет действие аккаунта в таблице activity вместе со временем.
 func (db *DB) SaveActivity(accountID, channelID, messageID int, activityType string) error {
 	_, err := db.Conn.Exec(
@@ -19,8 +22,15 @@ func (db *DB) SaveReaction(accountID, channelID, messageID int) error {
 	return db.SaveActivity(accountID, channelID, messageID, ActivityTypeReaction)
 }
 
-// HasComment проверяет, оставляла ли учетная запись комментарий к указанному посту.
-// Возвращает true, если запись с activity_type = 'comment' уже существует.
+// SaveComment сохраняет информацию о комментарии в таблице activity.
+// messageID — идентификатор созданного комментария.
+func (db *DB) SaveComment(accountID, channelID, messageID int) error {
+	return db.SaveActivity(accountID, channelID, messageID, ActivityTypeComment)
+}
+
+// HasComment проверяет, существует ли комментарий с указанным идентификатором
+// для заданной учетной записи. Возвращает true, если запись с activity_type = 'comment'
+// уже есть в таблице.
 func (db *DB) HasComment(accountID, messageID int) (bool, error) {
 	var exists bool
 	err := db.Conn.QueryRow(
@@ -30,9 +40,8 @@ func (db *DB) HasComment(accountID, messageID int) (bool, error) {
 	return exists, err
 }
 
-// HasCommentForPost проверяет, оставлялся ли комментарий к посту любым из наших аккаунтов.
-// Возвращает true, если в таблице activity есть запись с заданными каналом и постом
-// и типом activity_type = 'comment'.
+// HasCommentForPost проверяет, существует ли комментарий с указанным идентификатором
+// для заданного канала. Возвращает true при наличии записи с типом 'comment'.
 func (db *DB) HasCommentForPost(channelID, messageID int) (bool, error) {
 	var exists bool
 	err := db.Conn.QueryRow(

--- a/pkg/telegram/comment.go
+++ b/pkg/telegram/comment.go
@@ -132,8 +132,8 @@ func SendComment(db *storage.DB, accountID int, phone, channelURL string, apiID 
 			msgID = sentMsgID
 			// Сохраняем ID канала, приводя его к типу int
 			channelID = int(channel.ID)
-			// Записываем активность в таблицу activity
-			if err := module.SaveActivity(db, accountID, channelID, msgID, "comment"); err != nil {
+			// Записываем активность в таблицу activity по ID созданного комментария
+			if err := module.SaveCommentActivity(db, accountID, channelID, msgID); err != nil {
 				return fmt.Errorf("не удалось сохранить активность: %w", err)
 			}
 

--- a/pkg/telegram/module/save_activity.go
+++ b/pkg/telegram/module/save_activity.go
@@ -11,3 +11,9 @@ func SaveActivity(db *storage.DB, accountID, channelID, messageID int, activityT
 func SaveReactionActivity(db *storage.DB, accountID, channelID, messageID int) error {
 	return db.SaveReaction(accountID, channelID, messageID)
 }
+
+// SaveCommentActivity сохраняет комментарий с типом activity_type "comment".
+// messageID — ID созданного комментария в обсуждении.
+func SaveCommentActivity(db *storage.DB, accountID, channelID, messageID int) error {
+	return db.SaveComment(accountID, channelID, messageID)
+}


### PR DESCRIPTION
## Summary
- save comment activity using created comment ID
- document comment activity parameters

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68934bb5873083278d34ace65cfeec28