### PR TITLE
Fix activity save for comments

### DIFF
--- a/migrations/tables.sql
+++ b/migrations/tables.sql
@@ -20,8 +20,8 @@ CREATE TABLE IF NOT EXISTS channels (
 CREATE TABLE IF NOT EXISTS activity (
     id SERIAL PRIMARY KEY,
     id_account INTEGER NOT NULL,
-    id_channel INTEGER NOT NULL,
-    id_message INTEGER NOT NULL,
+    id_channel BIGINT NOT NULL,
+    id_message BIGINT NOT NULL,
     activity_type TEXT NOT NULL,
     date_time TIMESTAMP NOT NULL DEFAULT NOW()
 );

--- a/pkg/storage/activity.go
+++ b/pkg/storage/activity.go
@@ -5,6 +5,9 @@ import "time"
 // ActivityTypeReaction — значение поля activity_type для реакций.
 const ActivityTypeReaction = "reaction"
 
+// ActivityTypeComment — значение поля activity_type для комментариев.
+const ActivityTypeComment = "comment"
+
 // SaveActivity сохраняет действие аккаунта в таблице activity вместе со временем.
 func (db *DB) SaveActivity(accountID, channelID, messageID int, activityType string) error {
 	_, err := db.Conn.Exec(
@@ -19,8 +22,15 @@ func (db *DB) SaveReaction(accountID, channelID, messageID int) error {
 	return db.SaveActivity(accountID, channelID, messageID, ActivityTypeReaction)
 }
 
-// HasComment проверяет, оставляла ли учетная запись комментарий к указанному посту.
-// Возвращает true, если запись с activity_type = 'comment' уже существует.
+// SaveComment сохраняет информацию о комментарии в таблице activity.
+// messageID — идентификатор поста, к которому оставлен комментарий.
+func (db *DB) SaveComment(accountID, channelID, messageID int) error {
+	return db.SaveActivity(accountID, channelID, messageID, ActivityTypeComment)
+}
+
+// HasComment проверяет, существует ли комментарий с указанным идентификатором
+// для заданной учетной записи. Возвращает true, если запись с activity_type = 'comment'
+// уже есть в таблице.
 func (db *DB) HasComment(accountID, messageID int) (bool, error) {
 	var exists bool
 	err := db.Conn.QueryRow(
@@ -30,9 +40,8 @@ func (db *DB) HasComment(accountID, messageID int) (bool, error) {
 	return exists, err
 }
 
-// HasCommentForPost проверяет, оставлялся ли комментарий к посту любым из наших аккаунтов.
-// Возвращает true, если в таблице activity есть запись с заданными каналом и постом
-// и типом activity_type = 'comment'.
+// HasCommentForPost проверяет, существует ли комментарий с указанным идентификатором
+// для заданного канала. Возвращает true при наличии записи с типом 'comment'.
 func (db *DB) HasCommentForPost(channelID, messageID int) (bool, error) {
 	var exists bool
 	err := db.Conn.QueryRow(

--- a/pkg/telegram/comment.go
+++ b/pkg/telegram/comment.go
@@ -16,7 +16,7 @@ import (
 // SendComment подключается к Telegram, находит случайный пост в указанном канале
 // и отправляет случайный эмодзи в обсуждение этого поста.
 // После отправки сохраняет запись об активности в таблице activity.
-// Возвращает ID созданного комментария (int),
+// Возвращает ID поста, к которому оставлен комментарий (int),
 // ID исходного канала (int) и ошибку.
 // При неудаче оба идентификатора равны 0.
 func SendComment(db *storage.DB, accountID int, phone, channelURL string, apiID int, apiHash string, postsCount int, canSend func(channelID, messageID int) (bool, error), userIDs []int) (int, int, error) {
@@ -120,20 +120,20 @@ func SendComment(db *storage.DB, accountID int, phone, channelURL string, apiID 
 				continue
 			}
 
-			// Отправляем эмодзи и получаем ID созданного сообщения в обсуждении
-			sentMsgID, err := sendEmojiReply(ctx, api, &tg.InputPeerChannel{
+			// Отправляем эмодзи-ответ
+			if err := sendEmojiReply(ctx, api, &tg.InputPeerChannel{
 				ChannelID:  discussionData.Chat.ID,
 				AccessHash: discussionData.Chat.AccessHash,
-			}, replyToMsgID)
-			if err != nil {
+			}, replyToMsgID); err != nil {
 				return err
 			}
-			// Сохраняем ID созданного комментария
-			msgID = sentMsgID
+
+			// Сохраняем ID исходного поста
+			msgID = replyToMsgID
 			// Сохраняем ID канала, приводя его к типу int
 			channelID = int(channel.ID)
-			// Записываем активность в таблицу activity
-			if err := module.SaveActivity(db, accountID, channelID, msgID, "comment"); err != nil {
+			// Записываем активность в таблицу activity по ID поста
+			if err := module.SaveCommentActivity(db, accountID, channelID, msgID); err != nil {
 				return fmt.Errorf("не удалось сохранить активность: %w", err)
 			}
 
@@ -165,40 +165,24 @@ func getRandomEmoji() string {
 }
 
 // отправляет выбранный эмодзи как ответ на указанное сообщение
-// и возвращает ID созданного сообщения в обсуждении
-func sendEmojiReply(ctx context.Context, api *tg.Client, peer *tg.InputPeerChannel, replyToMsgID int) (int, error) {
+// при успешной отправке возвращает nil
+func sendEmojiReply(ctx context.Context, api *tg.Client, peer *tg.InputPeerChannel, replyToMsgID int) error {
 	// Получаем случайный эмодзи
 	emoji := getRandomEmoji()
 
-	// Отправляем эмодзи как ответ (peer и replyToMsgID уже заданы вызывающим)
-	upd, err := api.MessagesSendMessage(ctx, &tg.MessagesSendMessageRequest{
+	// Отправляем эмодзи как ответ
+	_, err := api.MessagesSendMessage(ctx, &tg.MessagesSendMessageRequest{
 		Peer:     peer,
 		Message:  emoji,
 		ReplyTo:  &tg.InputReplyToMessage{ReplyToMsgID: replyToMsgID},
 		RandomID: rand.Int63(),
 	})
-
 	if err != nil {
-		return 0, fmt.Errorf("не удалось отправить эмодзи: %w", err)
+		return fmt.Errorf("не удалось отправить эмодзи: %w", err)
 	}
 
-	// Пытаемся извлечь ID созданного сообщения
-	switch u := upd.(type) {
-	case *tg.Updates:
-		for _, update := range u.Updates {
-			if msgUpd, ok := update.(*tg.UpdateNewMessage); ok {
-				if m, ok := msgUpd.Message.(*tg.Message); ok {
-					log.Printf("Эмодзи %s успешно отправлен", emoji)
-					return m.ID, nil
-				}
-			}
-		}
-	case *tg.UpdateShortSentMessage:
-		log.Printf("Эмодзи %s успешно отправлен", emoji)
-		return u.ID, nil
-	}
-
-	return 0, fmt.Errorf("не удалось получить ID отправленного сообщения")
+	log.Printf("Эмодзи %s успешно отправлен", emoji)
+	return nil
 }
 
 // проверяет, есть ли среди последних комментариев к посту сообщения от наших аккаунтов

--- a/pkg/telegram/module/save_activity.go
+++ b/pkg/telegram/module/save_activity.go
@@ -11,3 +11,9 @@ func SaveActivity(db *storage.DB, accountID, channelID, messageID int, activityT
 func SaveReactionActivity(db *storage.DB, accountID, channelID, messageID int) error {
 	return db.SaveReaction(accountID, channelID, messageID)
 }
+
+// SaveCommentActivity сохраняет комментарий с типом activity_type "comment".
+// messageID — ID поста, к которому оставлен комментарий.
+func SaveCommentActivity(db *storage.DB, accountID, channelID, messageID int) error {
+	return db.SaveComment(accountID, channelID, messageID)
+}


### PR DESCRIPTION
## Summary
- save comment activity using original post ID
- simplify comment send logic and avoid message ID lookup
- allow big channel/message IDs in activity table

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68934bb5873083278d34ace65cfeec28