### PR TITLE
Добавлен контроль ID сообщений при реакциях

### DIFF
--- a/pkg/telegram/reaction.go
+++ b/pkg/telegram/reaction.go
@@ -96,6 +96,15 @@ func SendReaction(db *storage.DB, accountID int, phone, channelURL string, apiID
 		}
 		log.Printf("[DEBUG] Целевое сообщение ID=%d", targetMsg.ID)
 
+		// Проверяем, не слишком ли близко текущее сообщение к предыдущему
+		canReact, err := db.CanReactOnMessage(accountID, targetMsg.ID)
+		if err != nil {
+			return fmt.Errorf("не удалось проверить возможность реакции: %w", err)
+		}
+		if !canReact {
+			return fmt.Errorf("реакция на сообщение ID=%d запрещена: разница в ID должна быть не менее 10", targetMsg.ID)
+		}
+
 		// Выбираем реакцию: случайную из нашего списка, но если она не разрешена,
 		// используем первую разрешённую админами обсуждения.
 		reaction := pickReaction(reactionList, allowedReactions)


### PR DESCRIPTION
## Summary
- запрещена установка реакции на сообщения с ID ближе чем на 10 к предыдущему
- добавлены функции получения последнего ID реакции и проверки возможности реакции
- проверка выполняется перед отправкой реакции

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893869364908327a097d16199d002ea