### PR TITLE
fix: pass channel ID to CanReactOnMessage

### DIFF
--- a/pkg/telegram/reaction.go
+++ b/pkg/telegram/reaction.go
@@ -98,7 +98,8 @@ func SendReaction(db *storage.DB, accountID int, phone, channelURL string, apiID
 		log.Printf("[DEBUG] Целевое сообщение ID=%d", targetMsg.ID)
 
 		// Проверяем, не слишком ли близко текущее сообщение к предыдущему
-		canReact, err := db.CanReactOnMessage(accountID, targetMsg.ID)
+		// Передаём ID аккаунта, канала и сообщения
+		canReact, err := db.CanReactOnMessage(accountID, channelID, targetMsg.ID)
 		if err != nil {
 			return fmt.Errorf("не удалось проверить возможность реакции: %w", err)
 		}


### PR DESCRIPTION
## Summary
- provide channel ID when checking if a reaction can be sent

## Testing
- `go test ./...` *(fails: no response, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6893a90e11c48327af5e920d13c983b2