### PR TITLE
Добавлен request_body для ActivityRequest

### DIFF
--- a/internal/module/handler.go
+++ b/internal/module/handler.go
@@ -16,12 +16,13 @@ type Handler struct{}
 func NewHandler() *Handler { return &Handler{} }
 
 // DispatcherActivity запускает модульную активность диспатчера.
+// Ожидает JSON со списком activity_request, где у каждого запроса есть url и request_body.
 func (h *Handler) DispatcherActivity(c *gin.Context) {
 	var req struct {
-		TimeDelay       int                              `json:"time_delay" binding:"required"`
+		TimeDelay int `json:"time_delay" binding:"required"`
 
 		Repeat          int                              `json:"repeat" binding:"required"`
-		ActivityRequest []telegrammodule.ActivityRequest `json:"activity_request" binding:"required"`
+		ActivityRequest []telegrammodule.ActivityRequest `json:"activity_request" binding:"required"` // каждый элемент содержит url и произвольное request_body
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -30,7 +31,6 @@ func (h *Handler) DispatcherActivity(c *gin.Context) {
 	}
 
 	telegrammodule.ModF_DispatcherActivity(time.Duration(req.TimeDelay)*time.Second, req.Repeat, req.ActivityRequest)
-
 
 	c.JSON(http.StatusOK, gin.H{"status": "completed"})
 }

--- a/pkg/telegram/module/dispatcher_activity.go
+++ b/pkg/telegram/module/dispatcher_activity.go
@@ -7,17 +7,17 @@ import (
 	"time"
 )
 
-// ActivityRequest описывает один запрос активности с адресом и параметрами.
+// ActivityRequest описывает один запрос активности с адресом и произвольным телом.
 type ActivityRequest struct {
-	URL        string `json:"url"`
-	PostsCount int    `json:"posts_count"`
+	URL         string         `json:"url"`
+	RequestBody map[string]any `json:"request_body"`
 }
 
 // ModF_DispatcherActivity выполняет указанные запросы с заданным интервалом и количеством повторений.
 func ModF_DispatcherActivity(interval time.Duration, repeat int, activities []ActivityRequest) {
 	for i := 0; i < repeat; i++ {
 		for _, act := range activities {
-			payload, _ := json.Marshal(map[string]int{"posts_count": act.PostsCount})
+			payload, _ := json.Marshal(act.RequestBody)
 			http.Post(act.URL, "application/json", bytes.NewBuffer(payload))
 		}
 		if i < repeat-1 {


### PR DESCRIPTION
## Summary
- поддержан произвольный request_body в dispatcher activity
- описан формат activity_request в обработчике

## Testing
- `go test ./pkg/...` *(завис, пришлось прервать после сообщения о [no test files])*

------
https://chatgpt.com/codex/tasks/task_e_6893e23c9aa88327b68884fa5da7156c