### PR TITLE
Добавлен request_body для ActivityRequest

### DIFF
--- a/internal/module/handler.go
+++ b/internal/module/handler.go
@@ -16,12 +16,13 @@ type Handler struct{}
 func NewHandler() *Handler { return &Handler{} }
 
 // DispatcherActivity запускает модульную активность диспатчера.
+// Ожидает JSON со списком activity_request, где у каждого запроса есть url и request_body.
 func (h *Handler) DispatcherActivity(c *gin.Context) {
 	var req struct {
-		TimeDelay       int                              `json:"time_delay" binding:"required"`
+		TimeDelay int `json:"time_delay" binding:"required"`
 
 		Repeat          int                              `json:"repeat" binding:"required"`
-		ActivityRequest []telegrammodule.ActivityRequest `json:"activity_request" binding:"required"`
+		ActivityRequest []telegrammodule.ActivityRequest `json:"activity_request" binding:"required"` // каждый элемент содержит url и произвольное request_body
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -30,7 +31,6 @@ func (h *Handler) DispatcherActivity(c *gin.Context) {
 	}
 
 	telegrammodule.ModF_DispatcherActivity(time.Duration(req.TimeDelay)*time.Second, req.Repeat, req.ActivityRequest)
-
 
 	c.JSON(http.StatusOK, gin.H{"status": "completed"})
 }

--- a/migrations/tables.sql
+++ b/migrations/tables.sql
@@ -20,8 +20,8 @@ CREATE TABLE IF NOT EXISTS channels (
 CREATE TABLE IF NOT EXISTS activity (
     id SERIAL PRIMARY KEY,
     id_account INTEGER NOT NULL,
-    id_channel BIGINT NOT NULL,
-    id_message BIGINT NOT NULL,
+    id_channel VARCHAR(20) NOT NULL, -- ID канала как строка до 20 символов
+    id_message VARCHAR(20) NOT NULL, -- ID сообщения как строка до 20 символов
     activity_type TEXT NOT NULL,
     date_time TIMESTAMP NOT NULL DEFAULT NOW()
 );

--- a/models/activity.go
+++ b/models/activity.go
@@ -6,8 +6,8 @@ import "time"
 type Activity struct {
 	ID           int       `json:"id"`
 	AccountID    int       `json:"id_account"`
-	ChannelID    int       `json:"id_channel"`
-	MessageID    int       `json:"id_message"`
+	ChannelID    string    `json:"id_channel"`
+	MessageID    string    `json:"id_message"`
 	ActivityType string    `json:"activity_type"`
 	DateTime     time.Time `json:"date_time"`
 }

--- a/pkg/telegram/module/dispatcher_activity.go
+++ b/pkg/telegram/module/dispatcher_activity.go
@@ -7,17 +7,17 @@ import (
 	"time"
 )
 
-// ActivityRequest описывает один запрос активности с адресом и параметрами.
+// ActivityRequest описывает один запрос активности с адресом и произвольным телом.
 type ActivityRequest struct {
-	URL        string `json:"url"`
-	PostsCount int    `json:"posts_count"`
+	URL         string         `json:"url"`
+	RequestBody map[string]any `json:"request_body"`
 }
 
 // ModF_DispatcherActivity выполняет указанные запросы с заданным интервалом и количеством повторений.
 func ModF_DispatcherActivity(interval time.Duration, repeat int, activities []ActivityRequest) {
 	for i := 0; i < repeat; i++ {
 		for _, act := range activities {
-			payload, _ := json.Marshal(map[string]int{"posts_count": act.PostsCount})
+			payload, _ := json.Marshal(act.RequestBody)
 			http.Post(act.URL, "application/json", bytes.NewBuffer(payload))
 		}
 		if i < repeat-1 {


### PR DESCRIPTION
## Summary
- поддержан произвольный request_body в dispatcher activity
- описан формат activity_request в обработчике
- ID канала и сообщения в таблице activity сохраняются как строки

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6893e23c9aa88327b68884fa5da7156c