### PR TITLE
Сортировка постов и пропуск старых сообщений

### DIFF
--- a/pkg/telegram/comment.go
+++ b/pkg/telegram/comment.go
@@ -98,16 +98,16 @@ func SendComment(db *storage.DB, accountID int, phone, channelURL string, apiID 
 		}
 
 		// Просматриваем посты от новых к старым.
-		// Прекращаем проверку, если встретили пост с ID <= lastID.
+		// Пропускаем посты, которые были обработаны ранее (ID <= lastID).
 		// Количество проверок ограничено postsCount.
 		checked := 0 // счётчик проверенных постов
 		for _, p := range posts {
 			checked++
 
-			// Прерываем проверку, если дошли до последнего обработанного поста
+			// Пропускаем уже обработанные старые посты
 			if lastID != 0 && p.ID <= lastID {
-				log.Printf("[INFO] Достигнут ранее обработанный пост ID=%d, дальнейшая проверка не требуется", p.ID)
-				break
+				log.Printf("[INFO] Пропуск ранее обработанного поста ID=%d", p.ID)
+				continue
 			}
 
 			discussionData, err := module.Modf_getPostDiscussion(ctx, api, channel, p.ID)

--- a/pkg/telegram/module/channel_utils.go
+++ b/pkg/telegram/module/channel_utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"sort"
 	"strings"
 
 	"atg_go/models"
@@ -54,6 +55,11 @@ func GetChannelPosts(ctx context.Context, api *tg.Client, channel *tg.Channel, l
 	if len(validMessages) == 0 {
 		return nil, fmt.Errorf("no valid messages")
 	}
+
+	// Сортируем сообщения по убыванию ID, чтобы новые были первыми
+	sort.Slice(validMessages, func(i, j int) bool {
+		return validMessages[i].ID > validMessages[j].ID
+	})
 
 	return validMessages, nil
 }


### PR DESCRIPTION
## Summary
- сортировка сообщений канала по убыванию ID
- пропуск уже обработанных сообщений при обходе комментариев

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895256a15308327b2b252149b917ffb