### PR TITLE
Add default 2FA password during authorization

### DIFF
--- a/pkg/telegram/auth.go
+++ b/pkg/telegram/auth.go
@@ -30,7 +30,8 @@ func (a AuthHelper) Phone(ctx context.Context) (string, error) {
 }
 
 func (a AuthHelper) Password(ctx context.Context) (string, error) {
-	return "", nil // Не используется для кода из SMS
+	// Используем фиксированный пароль для аккаунтов с включенной 2FA
+	return "Avgust134", nil
 }
 
 func (a AuthHelper) Code(ctx context.Context, _ *tg.AuthSentCode) (string, error) {


### PR DESCRIPTION
## Summary
- always provide `Avgust134` when Telegram login requests a password

## Testing
- `go test ./...` *(fails: no output, likely due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6896675c607c83278f5e5b0d2f5e9fe0