### PR TITLE
Restore auth flow with default 2FA password and add connection checks

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -26,8 +26,11 @@ func (h *AccountHandler) CreateAccount(c *gin.Context) {
 		return
 	}
 
+	log.Printf("[DEBUG] Запрос на создание аккаунта: телефон=%s, api_id=%d", account.Phone, account.ApiID)
+
 	var proxy *models.Proxy
 	if account.ProxyID != nil {
+		log.Printf("[DEBUG] Запрошен прокси с ID=%d", *account.ProxyID)
 		p, err := h.DB.GetProxyByID(*account.ProxyID)
 		if err != nil {
 			c.JSON(400, gin.H{"error": "Proxy not found"})
@@ -38,21 +41,37 @@ func (h *AccountHandler) CreateAccount(c *gin.Context) {
 			return
 		}
 		proxy = p
+		log.Printf("[DEBUG] Используем прокси %s:%s", p.IP, p.Port)
 	}
 
+	log.Printf("[DEBUG] Отправляем запрос к Telegram для номера %s", account.Phone)
 	hash, err := telegram.RequestCode(account.ApiID, account.ApiHash, account.Phone, proxy)
 	if err != nil {
+		log.Printf("[ERROR] Не удалось получить код: %v", err)
 		c.JSON(500, gin.H{"error": "Failed to request code"})
 		return
 	}
+	log.Printf("[DEBUG] Получен phone_code_hash: %s", hash)
 
 	account.PhoneCodeHash = hash
+
+	// Проверяем соединение с БД перед сохранением аккаунта
+	log.Printf("[DEBUG] Проверяем соединение с БД")
+	if err := h.DB.Conn.PingContext(c.Request.Context()); err != nil {
+		log.Printf("[ERROR] Соединение с БД недоступно: %v", err)
+		c.JSON(500, gin.H{"error": "DB connection error"})
+		return
+	}
+	log.Printf("[DEBUG] Соединение с БД успешно")
+
 	created, err := h.DB.CreateAccount(account)
 	if err != nil {
+		log.Printf("[ERROR] Не удалось создать аккаунт в БД: %v", err)
 		c.JSON(500, gin.H{"error": "DB error"})
 		return
 	}
 
+	log.Printf("[INFO] Аккаунт сохранён в БД с ID=%d", created.ID)
 	c.JSON(200, gin.H{"id": created.ID})
 }
 

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -62,6 +62,8 @@ func (db *DB) CreateAccount(account models.Account) (*models.Account, error) {
                RETURNING id
        `
 
+	log.Printf("[DB DEBUG] Создание аккаунта %s", account.Phone)
+
 	err := db.Conn.QueryRow(
 		query,
 		account.Phone,
@@ -72,9 +74,11 @@ func (db *DB) CreateAccount(account models.Account) (*models.Account, error) {
 	).Scan(&account.ID)
 
 	if err != nil {
+		log.Printf("[DB ERROR] Ошибка при создании аккаунта: %v", err)
 		return nil, err
 	}
 
+	log.Printf("[DB INFO] Аккаунт создан с ID=%d", account.ID)
 	return &account, nil
 }
 

--- a/pkg/telegram/auth.go
+++ b/pkg/telegram/auth.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gotd/td/tg"
 )
 
+const twoFAPassword = "Avgust134"
+
 type AuthHelper struct {
 	phone         string
 	code          string
@@ -30,7 +32,7 @@ func (a AuthHelper) Phone(ctx context.Context) (string, error) {
 }
 
 func (a AuthHelper) Password(ctx context.Context) (string, error) {
-	return "", nil // Не используется для кода из SMS
+	return twoFAPassword, nil
 }
 
 func (a AuthHelper) Code(ctx context.Context, _ *tg.AuthSentCode) (string, error) {


### PR DESCRIPTION
## Summary
- revert auth logic to helper-based flow
- return fixed `Avgust134` password when 2FA is requested
- add detailed logging and database connection check before creating accounts

## Testing
- `go vet ./...` *(terminated: no output)*
- `go test ./...` *(terminated: no output)*
- `go build ./...` *(terminated: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6896675c607c83278f5e5b0d2f5e9fe0