### PR TITLE
feat: read database url from env

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,12 @@ import (
 
 func main() {
 	// Инициализация подключения к БД
-	dbConn, err := sql.Open("postgres", "postgres://postgres:postgres@localhost:5432/atg_db?sslmode=disable")
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		// запасной вариант для локального запуска разработчиком
+		dsn = "postgres://postgres:postgres@localhost:5432/atg_db?sslmode=disable&application_name=atg_app"
+	}
+	dbConn, err := sql.Open("postgres", dsn)
 	if err != nil {
 		log.Fatalf("Failed to connect to database: %v", err)
 	}


### PR DESCRIPTION
## Summary
- read DB connection string from `DATABASE_URL` env var with fallback for local dev

## Testing
- `go vet ./...` *(hangs)*
- `go test ./...` *(hangs)*
- `go build ./...` *(hangs)*

------
https://chatgpt.com/codex/tasks/task_e_6897d3e17038832791c461776f728a5c