### PR TITLE
Make comment limits and time window configurable

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -41,7 +41,7 @@ func (h *AccountHandler) CreateAccount(c *gin.Context) {
 			return
 		}
 		proxy = p
-		log.Printf("[DEBUG] Используем прокси %s:%s", p.IP, p.Port)
+		log.Printf("[DEBUG] Используем прокси %s:%d", p.IP, p.Port)
 	}
 
 	log.Printf("[DEBUG] Отправляем запрос к Telegram для номера %s", account.Phone)

--- a/internal/comments/handler.go
+++ b/internal/comments/handler.go
@@ -27,7 +27,9 @@ func NewHandler(db *storage.DB, commentDB *storage.CommentDB) *CommentHandler {
 
 func (h *CommentHandler) SendComment(c *gin.Context) {
 	var request struct {
-		PostsCount int `json:"posts_count" binding:"required"`
+		PostsCount   int   `json:"posts_count" binding:"required"`
+		MsgMax       []int `json:"msg_max" binding:"required"`
+		TimeRangeMSK []int `json:"time_range_msk" binding:"required"`
 	}
 
 	log.Printf("[HANDLER] Starting mass comment request")
@@ -35,6 +37,10 @@ func (h *CommentHandler) SendComment(c *gin.Context) {
 	if err := c.ShouldBindJSON(&request); err != nil {
 		log.Printf("[HANDLER ERROR] Invalid request: %v", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request format"})
+		return
+	}
+	if len(request.MsgMax) != 2 || len(request.TimeRangeMSK) != 2 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "msg_max and time_range_msk must have exactly 2 elements"})
 		return
 	}
 
@@ -67,6 +73,7 @@ func (h *CommentHandler) SendComment(c *gin.Context) {
 		}
 		userIDs = append(userIDs, id)
 	}
+	msk, _ := time.LoadLocation("Europe/Moscow")
 
 	for i, account := range accounts {
 		// Задержка между аккаунтами (чтобы не слишком быстро подряд)
@@ -90,6 +97,24 @@ func (h *CommentHandler) SendComment(c *gin.Context) {
 				// log.Printf("[HANDLER] %ds remaining...", remaining)
 				time.Sleep(5 * time.Second)
 			}
+		}
+
+		now := time.Now().In(msk)
+		if now.Hour() < request.TimeRangeMSK[0] || now.Hour() >= request.TimeRangeMSK[1] {
+			log.Printf("[HANDLER INFO] Время %s вне диапазона %d-%d МСК, пропуск для %s", now.Format(time.RFC3339), request.TimeRangeMSK[0], request.TimeRangeMSK[1], account.Phone)
+			continue
+		}
+
+		limit := dailyCommentLimit(account.ID, now, request.MsgMax[0], request.MsgMax[1])
+		count, err := h.DB.CountCommentsForDate(account.ID, now)
+		if err != nil {
+			log.Printf("[HANDLER ERROR] Не удалось получить количество комментариев для %s: %v", account.Phone, err)
+			errorCount++
+			continue
+		}
+		if count >= limit {
+			log.Printf("[HANDLER INFO] Достигнут дневной лимит комментариев (%d/%d) для %s", count, limit, account.Phone)
+			continue
 		}
 
 		// --- НОВАЯ ЛОГИКА: выбор канала для каждого аккаунта ---
@@ -149,4 +174,14 @@ func (h *CommentHandler) SendComment(c *gin.Context) {
 	}
 	log.Printf("[HANDLER INFO] Final result: %+v", result)
 	c.JSON(http.StatusOK, result)
+}
+
+func dailyCommentLimit(accountID int, date time.Time, min, max int) int {
+	if max < min {
+		max = min
+	}
+	day := time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, date.Location())
+	seed := int64(accountID) + day.Unix()
+	r := rand.New(rand.NewSource(seed))
+	return min + r.Intn(max-min+1)
 }

--- a/pkg/storage/activity.go
+++ b/pkg/storage/activity.go
@@ -44,6 +44,19 @@ func (db *DB) SaveComment(accountID, channelID, messageID int) error {
 	return db.SaveActivity(accountID, channelID, messageID, ActivityTypeComment)
 }
 
+// CountCommentsForDate возвращает количество комментариев, оставленных аккаунтом в указанную дату.
+// date интерпретируется в своей временной зоне.
+func (db *DB) CountCommentsForDate(accountID int, date time.Time) (int, error) {
+	start := time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, date.Location())
+	end := start.Add(24 * time.Hour)
+	var count int
+	err := db.Conn.QueryRow(
+		`SELECT COUNT(*) FROM activity WHERE id_account = $1 AND activity_type = $2 AND date_time >= $3 AND date_time < $4`,
+		accountID, ActivityTypeComment, start, end,
+	).Scan(&count)
+	return count, err
+}
+
 // HasComment проверяет, существует ли комментарий для поста с указанным ID у
 // заданной учетной записи. messageID должен содержать ID поста канала. Возвращает
 // true, если запись с activity_type = 'comment' уже есть в таблице.


### PR DESCRIPTION
## Summary
- allow `/comment/send` to define per-account comment quota via `msg_max`
- support Moscow time range from request using `time_range_msk`
- compute daily comment limits using provided range

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898d35482b08327bf909942b1a0feaa