### PR TITLE
Добавлены ограничения по времени и количеству реакций

### DIFF
--- a/internal/module/handler.go
+++ b/internal/module/handler.go
@@ -2,7 +2,6 @@ package module
 
 import (
 	"net/http"
-	"time"
 
 	telegrammodule "atg_go/pkg/telegram/module"
 
@@ -19,9 +18,7 @@ func NewHandler() *Handler { return &Handler{} }
 // Ожидает JSON со списком activity_request, где у каждого запроса есть url и request_body.
 func (h *Handler) DispatcherActivity(c *gin.Context) {
 	var req struct {
-		TimeDelay int `json:"time_delay" binding:"required"`
-
-		Repeat          int                              `json:"repeat" binding:"required"`
+		DaysNumber      int                              `json:"days_number" binding:"required"`
 		ActivityRequest []telegrammodule.ActivityRequest `json:"activity_request" binding:"required"` // каждый элемент содержит url и произвольное request_body
 	}
 
@@ -30,7 +27,8 @@ func (h *Handler) DispatcherActivity(c *gin.Context) {
 		return
 	}
 
-	telegrammodule.ModF_DispatcherActivity(time.Duration(req.TimeDelay)*time.Second, req.Repeat, req.ActivityRequest)
+	// Запускаем выполнение активностей в течение заданного количества суток
+	telegrammodule.ModF_DispatcherActivity(req.DaysNumber, req.ActivityRequest)
 
 	c.JSON(http.StatusOK, gin.H{"status": "completed"})
 }

--- a/pkg/storage/activity.go
+++ b/pkg/storage/activity.go
@@ -57,6 +57,19 @@ func (db *DB) CountCommentsForDate(accountID int, date time.Time) (int, error) {
 	return count, err
 }
 
+// CountReactionsForDate возвращает количество реакций, поставленных аккаунтом в указанную дату.
+// date интерпретируется в своей временной зоне.
+func (db *DB) CountReactionsForDate(accountID int, date time.Time) (int, error) {
+	start := time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, date.Location())
+	end := start.Add(24 * time.Hour)
+	var count int
+	err := db.Conn.QueryRow(
+		`SELECT COUNT(*) FROM activity WHERE id_account = $1 AND activity_type = $2 AND date_time >= $3 AND date_time < $4`,
+		accountID, ActivityTypeReaction, start, end,
+	).Scan(&count)
+	return count, err
+}
+
 // HasComment проверяет, существует ли комментарий для поста с указанным ID у
 // заданной учетной записи. messageID должен содержать ID поста канала. Возвращает
 // true, если запись с activity_type = 'comment' уже есть в таблице.

--- a/pkg/telegram/module/dispatcher_activity.go
+++ b/pkg/telegram/module/dispatcher_activity.go
@@ -3,7 +3,9 @@ package module
 import (
 	"bytes"
 	"encoding/json"
+	"math/rand"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -13,15 +15,56 @@ type ActivityRequest struct {
 	RequestBody map[string]any `json:"request_body"`
 }
 
-// ModF_DispatcherActivity выполняет указанные запросы с заданным интервалом и количеством повторений.
-func ModF_DispatcherActivity(interval time.Duration, repeat int, activities []ActivityRequest) {
-	for i := 0; i < repeat; i++ {
+// ModF_DispatcherActivity выполняет запросы активности, распределяя их по суткам и указанным временным окнам.
+// daysNumber задаёт, сколько суток подряд выполняется активность.
+func ModF_DispatcherActivity(daysNumber int, activities []ActivityRequest) {
+	rand.Seed(time.Now().UnixNano())
+
+	start := time.Now()
+
+	for day := 0; day < daysNumber; day++ {
+		var wg sync.WaitGroup
+
 		for _, act := range activities {
-			payload, _ := json.Marshal(act.RequestBody)
-			http.Post(act.URL, "application/json", bytes.NewBuffer(payload))
+			wg.Add(1)
+
+			go func(act ActivityRequest, offset int) {
+				defer wg.Done()
+
+				period, ok1 := act.RequestBody["dispatcher_period"].([]interface{})
+				maxRange, ok2 := act.RequestBody["dispatcher_activity_max"].([]interface{})
+				if !ok1 || !ok2 || len(period) != 2 || len(maxRange) != 2 {
+					return
+				}
+
+				// извлекаем часы начала и конца окна
+				startHour := int(period[0].(float64))
+				endHour := int(period[1].(float64))
+				minAct := int(maxRange[0].(float64))
+				maxAct := int(maxRange[1].(float64))
+
+				if endHour <= startHour || maxAct < minAct {
+					return
+				}
+
+				count := rand.Intn(maxAct-minAct+1) + minAct
+
+				currentDay := start.AddDate(0, 0, offset)
+				windowStart := time.Date(currentDay.Year(), currentDay.Month(), currentDay.Day(), startHour, 0, 0, 0, time.Local)
+				duration := time.Duration(endHour-startHour) * time.Hour
+				interval := duration / time.Duration(count)
+
+				for i := 0; i < count; i++ {
+					t := windowStart.Add(interval * time.Duration(i))
+					if sleep := time.Until(t); sleep > 0 {
+						time.Sleep(sleep)
+					}
+					payload, _ := json.Marshal(act.RequestBody)
+					http.Post(act.URL, "application/json", bytes.NewBuffer(payload))
+				}
+			}(act, day)
 		}
-		if i < repeat-1 {
-			time.Sleep(interval)
-		}
+
+		wg.Wait()
 	}
 }


### PR DESCRIPTION
## Summary
- эндпоинт `/module/dispatcher_activity` работает несколько суток и принимает `days_number`
- активности равномерно распределяются в пределах `dispatcher_period`

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a31a5faa88327a873dd375803d078