### PR TITLE
Refactor dispatcher activity configuration

### DIFF
--- a/internal/module/handler.go
+++ b/internal/module/handler.go
@@ -18,8 +18,10 @@ func NewHandler() *Handler { return &Handler{} }
 // Ожидает JSON со списком activity_request, где у каждого запроса есть url и request_body.
 func (h *Handler) DispatcherActivity(c *gin.Context) {
 	var req struct {
-		DaysNumber      int                              `json:"days_number" binding:"required"`
-		ActivityRequest []telegrammodule.ActivityRequest `json:"activity_request" binding:"required"` // каждый элемент содержит url и произвольное request_body
+		DaysNumber       int                              `json:"days_number" binding:"required"`
+		ActivityRequest  []telegrammodule.ActivityRequest `json:"activity_request" binding:"required"`
+		ActivityComment  telegrammodule.ActivitySettings  `json:"activity_comment" binding:"required"`
+		ActivityReaction telegrammodule.ActivitySettings  `json:"activity_reaction" binding:"required"`
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -28,7 +30,7 @@ func (h *Handler) DispatcherActivity(c *gin.Context) {
 	}
 
 	// Запускаем выполнение активностей в течение заданного количества суток
-	telegrammodule.ModF_DispatcherActivity(req.DaysNumber, req.ActivityRequest)
+	telegrammodule.ModF_DispatcherActivity(req.DaysNumber, req.ActivityRequest, req.ActivityComment, req.ActivityReaction)
 
 	c.JSON(http.StatusOK, gin.H{"status": "completed"})
 }

--- a/internal/reaction/handler.go
+++ b/internal/reaction/handler.go
@@ -30,9 +30,7 @@ func NewHandler(db *storage.DB, commentDB *storage.CommentDB) *ReactionHandler {
 // SendReaction добавляет реакции к сообщениям обсуждений во всех каналах.
 func (h *ReactionHandler) SendReaction(c *gin.Context) {
 	var request struct {
-		MsgCount              int      `json:"msg_count" binding:"required"`
-		DispatcherActivityMax []int    `json:"dispatcher_activity_max" binding:"required"`
-		DispatcherPeriod      []string `json:"dispatcher_period" binding:"required"`
+		MsgCount int `json:"msg_count" binding:"required"`
 	}
 
 	log.Printf("[HANDLER] Запуск массовой отправки реакций")
@@ -40,10 +38,6 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 	if err := c.ShouldBindJSON(&request); err != nil {
 		log.Printf("[HANDLER ERROR] Неверный формат запроса: %v", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request format"})
-		return
-	}
-	if len(request.DispatcherActivityMax) != 2 || len(request.DispatcherPeriod) != 2 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "dispatcher_activity_max and dispatcher_period must have exactly 2 elements"})
 		return
 	}
 
@@ -65,18 +59,6 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 
 	rand.Seed(time.Now().UnixNano())
 
-	msk := time.FixedZone("MSK", 3*3600)
-
-	startTime, err1 := time.Parse("15:04", request.DispatcherPeriod[0])
-	endTime, err2 := time.Parse("15:04", request.DispatcherPeriod[1])
-	if err1 != nil || err2 != nil {
-		log.Printf("[HANDLER ERROR] Неверный формат dispatcher_period: %v %v", err1, err2)
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid dispatcher_period format"})
-		return
-	}
-	startMin := startTime.Hour()*60 + startTime.Minute()
-	endMin := endTime.Hour()*60 + endTime.Minute()
-
 	for i, account := range accounts {
 		// Задержка между аккаунтами
 		if i > 0 {
@@ -97,33 +79,6 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 				}
 				time.Sleep(5 * time.Second)
 			}
-		}
-
-		now := time.Now().In(msk)
-		current := now.Hour()*60 + now.Minute()
-
-		var outOfRange bool
-		if startMin < endMin {
-			outOfRange = current < startMin || current >= endMin
-		} else {
-			outOfRange = current < startMin && current >= endMin
-		}
-
-		if outOfRange {
-			log.Printf("[HANDLER INFO] Время %s вне диапазона %s-%s МСК, пропуск для %s", now.Format(time.RFC3339), request.DispatcherPeriod[0], request.DispatcherPeriod[1], account.Phone)
-			continue
-		}
-
-		limit := dailyReactionLimit(account.ID, now, request.DispatcherActivityMax[0], request.DispatcherActivityMax[1])
-		count, err := h.DB.CountReactionsForDate(account.ID, now)
-		if err != nil {
-			log.Printf("[HANDLER ERROR] Не удалось получить количество реакций для %s: %v", account.Phone, err)
-			errorCount++
-			continue
-		}
-		if count >= limit {
-			log.Printf("[HANDLER INFO] Достигнут дневной лимит реакций (%d/%d) для %s", count, limit, account.Phone)
-			continue
 		}
 
 		// Выбор случайного канала
@@ -173,15 +128,4 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 	}
 	log.Printf("[HANDLER INFO] Итог: %+v", result)
 	c.JSON(http.StatusOK, result)
-}
-
-// dailyReactionLimit вычисляет дневной лимит реакций для аккаунта в заданном диапазоне.
-func dailyReactionLimit(accountID int, date time.Time, min, max int) int {
-	if max < min {
-		max = min
-	}
-	day := time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, date.Location())
-	seed := int64(accountID) + day.Unix()
-	r := rand.New(rand.NewSource(seed))
-	return min + r.Intn(max-min+1)
 }


### PR DESCRIPTION
## Summary
- remove dispatcher timing params from comment and reaction handlers
- centralize scheduling via new activity_comment and activity_reaction fields
- send internal requests with authorization header in dispatcher activity module

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a50714c3883279e5cc2fad65240e2