### PR TITLE
Создание аккаунта до запроса кода авторизации

### DIFF
--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -158,6 +158,16 @@ func (db *DB) MarkAccountAsAuthorized(accountID int) error {
 	return err
 }
 
+// Обновляет phone_code_hash для указанного аккаунта
+func (db *DB) UpdatePhoneCodeHash(accountID int, hash string) error {
+	_, err := db.Conn.Exec(
+		"UPDATE accounts SET phone_code_hash = $1 WHERE id = $2",
+		hash,
+		accountID,
+	)
+	return err
+}
+
 func (db *DB) GetAccountByPhone(phone string) (*models.Account, error) {
 	var account models.Account
 


### PR DESCRIPTION
## Summary
- сначала сохраняем аккаунт и только потом запрашиваем код подтверждения
- RequestCode принимает DB и accountID, обновляя `phone_code_hash`
- добавлен метод обновления `phone_code_hash` в storage

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a7322ee4883278a7e403655e2036b