### PR TITLE
Добавлен эндпоинт для массовой отписки от каналов

### DIFF
--- a/internal/module/handler.go
+++ b/internal/module/handler.go
@@ -3,16 +3,19 @@ package module
 import (
 	"net/http"
 
+	"atg_go/pkg/storage"
 	telegrammodule "atg_go/pkg/telegram/module"
 
 	"github.com/gin-gonic/gin"
 )
 
 // Handler обрабатывает запросы к модулю Telegram.
-type Handler struct{}
+type Handler struct {
+	DB *storage.DB
+}
 
 // NewHandler создает новый экземпляр обработчика.
-func NewHandler() *Handler { return &Handler{} }
+func NewHandler(db *storage.DB) *Handler { return &Handler{DB: db} }
 
 // DispatcherActivity запускает модульную активность диспатчера.
 // Ожидает JSON со списком activity_request, где у каждого запроса есть url и request_body.
@@ -32,5 +35,14 @@ func (h *Handler) DispatcherActivity(c *gin.Context) {
 	// Запускаем выполнение активностей в течение заданного количества суток
 	telegrammodule.ModF_DispatcherActivity(req.DaysNumber, req.ActivityRequest, req.ActivityComment, req.ActivityReaction)
 
+	c.JSON(http.StatusOK, gin.H{"status": "completed"})
+}
+
+// Unsubscribe отключает все аккаунты от всех каналов и групп.
+func (h *Handler) Unsubscribe(c *gin.Context) {
+	if err := telegrammodule.ModF_UnsubscribeAll(h.DB); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{"status": "completed"})
 }

--- a/internal/module/routes.go
+++ b/internal/module/routes.go
@@ -1,9 +1,14 @@
 package module
 
-import "github.com/gin-gonic/gin"
+import (
+	"atg_go/pkg/storage"
+
+	"github.com/gin-gonic/gin"
+)
 
 // SetupRoutes регистрирует маршруты модуля.
-func SetupRoutes(r *gin.RouterGroup) {
-	handler := NewHandler()
+func SetupRoutes(r *gin.RouterGroup, db *storage.DB) {
+	handler := NewHandler(db)
 	r.POST("/dispatcher_activity", handler.DispatcherActivity)
+	r.POST("/unsubscribe", handler.Unsubscribe)
 }

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func setupRouter(db *storage.DB, commentDB *storage.CommentDB) *gin.Engine {
 
 	// Группа роутов для telegram-модуля
 	moduleGroup := r.Group("/module")
-	module.SetupRoutes(moduleGroup)
+	module.SetupRoutes(moduleGroup, db)
 
 	// Health check endpoint
 	r.GET("/health", func(c *gin.Context) {

--- a/pkg/telegram/module/unsubscribe.go
+++ b/pkg/telegram/module/unsubscribe.go
@@ -1,0 +1,74 @@
+package module
+
+import (
+	"context"
+	"log"
+
+	"atg_go/models"
+	"atg_go/pkg/storage"
+
+	"github.com/gotd/td/tg"
+)
+
+// ModF_UnsubscribeAll отключает все аккаунты от каналов и групп.
+func ModF_UnsubscribeAll(db *storage.DB) error {
+	accounts, err := db.GetAuthorizedAccounts()
+	if err != nil {
+		return err
+	}
+	for _, acc := range accounts {
+		if err := unsubscribeAccount(db, &acc); err != nil {
+			log.Printf("[UNSUBSCRIBE] аккаунт %d: %v", acc.ID, err)
+		}
+	}
+	return nil
+}
+
+// unsubscribeAccount выходит из всех каналов и групп для одного аккаунта.
+func unsubscribeAccount(db *storage.DB, acc *models.Account) error {
+	client, err := Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	return client.Run(ctx, func(ctx context.Context) error {
+		api := tg.NewClient(client)
+		res, err := api.MessagesGetDialogs(ctx, &tg.MessagesGetDialogsRequest{Limit: 100})
+		if err != nil {
+			return err
+		}
+		dialogs, ok := res.AsModified()
+		if !ok {
+			return nil
+		}
+		for _, raw := range dialogs.GetDialogs() {
+			d, ok := raw.(*tg.Dialog)
+			if !ok {
+				continue
+			}
+			switch peer := d.Peer.(type) {
+			case *tg.PeerChannel:
+				if ch := findChannel(dialogs.GetChats(), peer.ChannelID); ch != nil {
+					if _, err := api.ChannelsLeaveChannel(ctx, &tg.InputChannel{ChannelID: ch.ID, AccessHash: ch.AccessHash}); err != nil {
+						log.Printf("[UNSUBSCRIBE] не удалось покинуть канал %d: %v", ch.ID, err)
+					}
+				}
+			case *tg.PeerChat:
+				if _, err := api.MessagesDeleteChatUser(ctx, &tg.MessagesDeleteChatUserRequest{ChatID: peer.ChatID, UserID: &tg.InputUserSelf{}}); err != nil {
+					log.Printf("[UNSUBSCRIBE] не удалось покинуть группу %d: %v", peer.ChatID, err)
+				}
+			}
+		}
+		return nil
+	})
+}
+
+// findChannel ищет канал по идентификатору среди чатов.
+func findChannel(chats []tg.ChatClass, id int64) *tg.Channel {
+	for _, ch := range chats {
+		if c, ok := ch.(*tg.Channel); ok && c.ID == id {
+			return c
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- добавлен обработчик и роут для запроса `/module/unsubscribe`
- реализована логика отписки всех аккаунтов от всех каналов и групп

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689affd52bb08327991f2f760910d817