### PR TITLE
Логирование адреса канала при отписке

### DIFF
--- a/internal/module/handler.go
+++ b/internal/module/handler.go
@@ -1,18 +1,22 @@
 package module
 
 import (
+	"log"
 	"net/http"
 
+	"atg_go/pkg/storage"
 	telegrammodule "atg_go/pkg/telegram/module"
 
 	"github.com/gin-gonic/gin"
 )
 
 // Handler обрабатывает запросы к модулю Telegram.
-type Handler struct{}
+type Handler struct {
+	DB *storage.DB
+}
 
 // NewHandler создает новый экземпляр обработчика.
-func NewHandler() *Handler { return &Handler{} }
+func NewHandler(db *storage.DB) *Handler { return &Handler{DB: db} }
 
 // DispatcherActivity запускает модульную активность диспатчера.
 // Ожидает JSON со списком activity_request, где у каждого запроса есть url и request_body.
@@ -32,5 +36,53 @@ func (h *Handler) DispatcherActivity(c *gin.Context) {
 	// Запускаем выполнение активностей в течение заданного количества суток
 	telegrammodule.ModF_DispatcherActivity(req.DaysNumber, req.ActivityRequest, req.ActivityComment, req.ActivityReaction)
 
+	c.JSON(http.StatusOK, gin.H{"status": "completed"})
+}
+
+// Unsubscribe обрабатывает POST /module/unsubscribe.
+//
+// Запрос (JSON):
+//
+//	{
+//	  "delay": [min, max],               // массив из двух чисел с диапазоном задержки в секундах
+//	  "number_channels_or_groups": N     // количество каналов/групп (1–9)
+//	}
+//
+// Ответ (200, JSON):
+// { "status": "completed" }
+//
+// Возможные ошибки:
+// - 400: неверный формат запроса
+// - 400: delay должен содержать два значения
+// - 400: number_channels_or_groups должен быть числом от 1 до 9
+// - 500: внутренняя ошибка отписки
+func (h *Handler) Unsubscribe(c *gin.Context) {
+	var req struct {
+		Delay                  []int `json:"delay" binding:"required"`
+		NumberChannelsOrGroups int   `json:"number_channels_or_groups" binding:"required"`
+	}
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "неверный формат запроса"})
+		return
+	}
+
+	if len(req.Delay) != 2 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "delay должен содержать два значения"})
+		return
+	}
+
+	if req.NumberChannelsOrGroups <= 0 || req.NumberChannelsOrGroups > 9 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "number_channels_or_groups должен быть числом от 1 до 9"})
+		return
+	}
+
+	delayRange := [2]int{req.Delay[0], req.Delay[1]}
+	log.Printf("[UNSUBSCRIBE] запрос: delay=%v, count=%d", delayRange, req.NumberChannelsOrGroups)
+
+	if err := telegrammodule.ModF_UnsubscribeAll(h.DB, delayRange, req.NumberChannelsOrGroups); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{"status": "completed"})
 }

--- a/internal/module/routes.go
+++ b/internal/module/routes.go
@@ -1,9 +1,14 @@
 package module
 
-import "github.com/gin-gonic/gin"
+import (
+	"atg_go/pkg/storage"
+
+	"github.com/gin-gonic/gin"
+)
 
 // SetupRoutes регистрирует маршруты модуля.
-func SetupRoutes(r *gin.RouterGroup) {
-	handler := NewHandler()
+func SetupRoutes(r *gin.RouterGroup, db *storage.DB) {
+	handler := NewHandler(db)
 	r.POST("/dispatcher_activity", handler.DispatcherActivity)
+	r.POST("/unsubscribe", handler.Unsubscribe)
 }

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func setupRouter(db *storage.DB, commentDB *storage.CommentDB) *gin.Engine {
 
 	// Группа роутов для telegram-модуля
 	moduleGroup := r.Group("/module")
-	module.SetupRoutes(moduleGroup)
+	module.SetupRoutes(moduleGroup, db)
 
 	// Health check endpoint
 	r.GET("/health", func(c *gin.Context) {

--- a/pkg/telegram/module/unsubscribe.go
+++ b/pkg/telegram/module/unsubscribe.go
@@ -1,0 +1,112 @@
+package module
+
+import (
+	"context"
+	"log"
+	"math/rand"
+	"time"
+
+	"atg_go/models"
+	"atg_go/pkg/storage"
+
+	"github.com/gotd/td/tg"
+)
+
+// ModF_UnsubscribeAll отключает указанное количество каналов и групп у всех аккаунтов.
+func ModF_UnsubscribeAll(db *storage.DB, delay [2]int, limit int) error {
+	rand.Seed(time.Now().UnixNano())
+	accounts, err := db.GetAuthorizedAccounts()
+	if err != nil {
+		return err
+	}
+	for _, acc := range accounts {
+		log.Printf("[UNSUBSCRIBE] аккаунт %d: начало обработки", acc.ID)
+		if err := unsubscribeAccount(db, &acc, delay, limit); err != nil {
+			log.Printf("[UNSUBSCRIBE] аккаунт %d: %v", acc.ID, err)
+		} else {
+			log.Printf("[UNSUBSCRIBE] аккаунт %d: завершено", acc.ID)
+		}
+	}
+	return nil
+}
+
+// unsubscribeAccount выходит из указанного количества каналов и групп для одного аккаунта.
+func unsubscribeAccount(db *storage.DB, acc *models.Account, delay [2]int, limit int) error {
+	client, err := Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	return client.Run(ctx, func(ctx context.Context) error {
+		api := tg.NewClient(client)
+		res, err := api.MessagesGetDialogs(ctx, &tg.MessagesGetDialogsRequest{
+			Limit:      100,
+			OffsetPeer: &tg.InputPeerEmpty{},
+		})
+		if err != nil {
+			return err
+		}
+		dialogs, ok := res.AsModified()
+		if !ok {
+			return nil
+		}
+		count := 0
+		for _, raw := range dialogs.GetDialogs() {
+			if count >= limit {
+				break
+			}
+			d, ok := raw.(*tg.Dialog)
+			if !ok {
+				continue
+			}
+			switch peer := d.Peer.(type) {
+			case *tg.PeerChannel:
+				if ch := findChannel(dialogs.GetChats(), peer.ChannelID); ch != nil {
+					time.Sleep(randomDelay(delay))
+					if _, err := api.ChannelsLeaveChannel(ctx, &tg.InputChannel{ChannelID: ch.ID, AccessHash: ch.AccessHash}); err != nil {
+						log.Printf("[UNSUBSCRIBE] аккаунт %d не покинул канал %d: %v", acc.ID, ch.ID, err)
+					} else {
+						log.Printf("[UNSUBSCRIBE] аккаунт %d покинул канал %d (%s)", acc.ID, ch.ID, channelAddress(ch))
+						count++
+					}
+				}
+			case *tg.PeerChat:
+				time.Sleep(randomDelay(delay))
+				if _, err := api.MessagesDeleteChatUser(ctx, &tg.MessagesDeleteChatUserRequest{ChatID: peer.ChatID, UserID: &tg.InputUserSelf{}}); err != nil {
+					log.Printf("[UNSUBSCRIBE] аккаунт %d не покинул группу %d: %v", acc.ID, peer.ChatID, err)
+				} else {
+					log.Printf("[UNSUBSCRIBE] аккаунт %d покинул группу %d", acc.ID, peer.ChatID)
+					count++
+				}
+			}
+		}
+		return nil
+	})
+}
+
+// findChannel ищет канал по идентификатору среди чатов.
+func findChannel(chats []tg.ChatClass, id int64) *tg.Channel {
+	for _, ch := range chats {
+		if c, ok := ch.(*tg.Channel); ok && c.ID == id {
+			return c
+		}
+	}
+	return nil
+}
+
+// channelAddress формирует ссылку на канал или возвращает заглушку, если адреса нет.
+func channelAddress(ch *tg.Channel) string {
+	if ch.Username != "" {
+		return "https://t.me/" + ch.Username
+	}
+	return "адрес недоступен"
+}
+
+// randomDelay возвращает случайную задержку в заданном диапазоне.
+func randomDelay(r [2]int) time.Duration {
+	if r[1] <= r[0] {
+		return time.Duration(r[0]) * time.Second
+	}
+	d := rand.Intn(r[1]-r[0]+1) + r[0]
+	return time.Duration(d) * time.Second
+}


### PR DESCRIPTION
## Summary
- выводим ссылку на канал вместе с его ID при отписке
- документирован JSON-запрос для `/module/unsubscribe` с допустимыми значениями и ошибками

## Testing
- `go test ./...` (команда не дала вывода и была остановлена вручную)


------
https://chatgpt.com/codex/tasks/task_e_689affd52bb08327991f2f760910d817