### PR TITLE
Добавлен механизм блокировки аккаунтов

### DIFF
--- a/internal/module/account_deadlock/account_deadlock.go
+++ b/internal/module/account_deadlock/account_deadlock.go
@@ -1,0 +1,13 @@
+package account_deadlock
+
+import pkgdeadlock "atg_go/pkg/telegram/module/account_deadlock"
+
+// LockAccount экспортирует блокировку аккаунта для внутренних пакетов.
+func LockAccount(accountID int) error {
+	return pkgdeadlock.LockAccount(accountID)
+}
+
+// UnlockAccount освобождает блокировку аккаунта.
+func UnlockAccount(accountID int) {
+	pkgdeadlock.UnlockAccount(accountID)
+}

--- a/pkg/telegram/comment.go
+++ b/pkg/telegram/comment.go
@@ -10,6 +10,7 @@ import (
 	"atg_go/models"
 	"atg_go/pkg/storage"
 	module "atg_go/pkg/telegram/module"
+	accountdeadlock "atg_go/pkg/telegram/module/account_deadlock"
 
 	"github.com/gotd/td/tg"
 )
@@ -22,6 +23,13 @@ import (
 // При неудаче оба идентификатора равны 0.
 func SendComment(db *storage.DB, accountID int, phone, channelURL string, apiID int, apiHash string, postsCount int, canSend func(channelID, messageID int) (bool, error), userIDs []int, proxy *models.Proxy) (int, int, error) {
 	log.Printf("[START] Отправка эмодзи в канал %s от имени %s", channelURL, phone)
+
+	// Блокируем аккаунт, чтобы избежать параллельного использования
+	if err := accountdeadlock.LockAccount(accountID); err != nil {
+		return 0, 0, err
+	}
+	// Гарантируем освобождение мьютекса после завершения работы
+	defer accountdeadlock.UnlockAccount(accountID)
 
 	// Извлекаем username из URL канала (например, из "https://t.me/channel" извлекаем "channel")
 	username, err := module.Modf_ExtractUsername(channelURL)

--- a/pkg/telegram/module/account_deadlock/account_deadlock.go
+++ b/pkg/telegram/module/account_deadlock/account_deadlock.go
@@ -1,0 +1,38 @@
+package account_deadlock
+
+import (
+	"fmt"
+	"sync"
+)
+
+var (
+	globalMu     sync.Mutex
+	accountLocks = make(map[int]*sync.Mutex)
+)
+
+// LockAccount пытается захватить мьютекс для указанного аккаунта.
+// Если аккаунт уже используется, возвращается ошибка.
+func LockAccount(accountID int) error {
+	globalMu.Lock()
+	lock, ok := accountLocks[accountID]
+	if !ok {
+		lock = &sync.Mutex{}
+		accountLocks[accountID] = lock
+	}
+	globalMu.Unlock()
+
+	if !lock.TryLock() {
+		return fmt.Errorf("аккаунт %d уже используется", accountID)
+	}
+	return nil
+}
+
+// UnlockAccount освобождает мьютекс для указанного аккаунта.
+func UnlockAccount(accountID int) {
+	globalMu.Lock()
+	lock := accountLocks[accountID]
+	globalMu.Unlock()
+	if lock != nil {
+		lock.Unlock()
+	}
+}


### PR DESCRIPTION
## Summary
- Добавлен пакет `account_deadlock` с глобальной картой мьютексов для аккаунтов
- Обработчики комментариев и реакций теперь блокируют аккаунт перед инициализацией клиента
- Добавлен внутренний модуль для экспорта функций блокировки

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689da3879e848327a5b9bdbd78586fc7