### PR TITLE
Добавлен механизм блокировки аккаунтов

### DIFF
--- a/internal/module/account_mutex/account_mutex.go
+++ b/internal/module/account_mutex/account_mutex.go
@@ -1,0 +1,13 @@
+package account_mutex
+
+import pkgmutex "atg_go/pkg/telegram/module/account_mutex"
+
+// LockAccount экспортирует блокировку аккаунта для внутренних пакетов.
+func LockAccount(accountID int) error {
+	return pkgmutex.LockAccount(accountID)
+}
+
+// UnlockAccount освобождает блокировку аккаунта.
+func UnlockAccount(accountID int) {
+	pkgmutex.UnlockAccount(accountID)
+}

--- a/pkg/telegram/module/account_mutex/account_mutex.go
+++ b/pkg/telegram/module/account_mutex/account_mutex.go
@@ -1,0 +1,48 @@
+package account_mutex
+
+import (
+	"fmt"
+	"log"
+	"sync"
+)
+
+var (
+	globalMu     sync.Mutex
+	accountLocks = make(map[int]*sync.Mutex)
+)
+
+// LockAccount пытается захватить мьютекс для указанного аккаунта.
+// Если аккаунт уже используется, возвращается ошибка.
+// В журнал записывается информация о попытке, успешной блокировке
+// и отказе в случае занятости.
+func LockAccount(accountID int) error {
+	log.Printf("[MUTEX] попытка блокировки аккаунта %d", accountID)
+
+	globalMu.Lock()
+	lock, ok := accountLocks[accountID]
+	if !ok {
+		lock = &sync.Mutex{}
+		accountLocks[accountID] = lock
+	}
+	globalMu.Unlock()
+
+	if !lock.TryLock() {
+		log.Printf("[MUTEX] аккаунт %d занят", accountID)
+		return fmt.Errorf("аккаунт %d уже используется", accountID)
+	}
+
+	log.Printf("[MUTEX] аккаунт %d заблокирован", accountID)
+	return nil
+}
+
+// UnlockAccount освобождает мьютекс для указанного аккаунта
+// и записывает это событие в журнал.
+func UnlockAccount(accountID int) {
+	globalMu.Lock()
+	lock := accountLocks[accountID]
+	globalMu.Unlock()
+	if lock != nil {
+		lock.Unlock()
+		log.Printf("[MUTEX] аккаунт %d разблокирован", accountID)
+	}
+}

--- a/pkg/telegram/reaction.go
+++ b/pkg/telegram/reaction.go
@@ -10,6 +10,7 @@ import (
 	"atg_go/models"
 	"atg_go/pkg/storage"
 	module "atg_go/pkg/telegram/module"
+	accountmutex "atg_go/pkg/telegram/module/account_mutex"
 
 	"github.com/gotd/td/tg"
 )
@@ -22,6 +23,13 @@ import (
 // ошибку. При неудаче оба идентификатора равны 0.
 func SendReaction(db *storage.DB, accountID int, phone, channelURL string, apiID int, apiHash string, msgCount int, proxy *models.Proxy) (int, int, error) {
 	log.Printf("[START] Отправка реакции в канал %s от имени %s", channelURL, phone)
+
+	// Захватываем мьютекс для аккаунта, чтобы исключить параллельное использование
+	if err := accountmutex.LockAccount(accountID); err != nil {
+		return 0, 0, err
+	}
+	// Освобождаем мьютекс по завершении работы
+	defer accountmutex.UnlockAccount(accountID)
 
 	username, err := module.Modf_ExtractUsername(channelURL)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Переименован модуль `account_deadlock` в `account_mutex`
- Добавлены журнальные сообщения при блокировке и разблокировке аккаунтов
- Обработчики комментариев и реакций используют новый модуль мьютексов

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689da3879e848327a5b9bdbd78586fc7