### PR TITLE
Добавлен механизм блокировки аккаунтов

### DIFF
--- a/internal/module/account_mutex/account_mutex.go
+++ b/internal/module/account_mutex/account_mutex.go
@@ -1,0 +1,48 @@
+package account_mutex
+
+import (
+	"fmt"
+	"log"
+	"sync"
+)
+
+var (
+	globalMu     sync.Mutex
+	accountLocks = make(map[int]*sync.Mutex)
+)
+
+// LockAccount пытается захватить мьютекс для указанного аккаунта.
+// Если аккаунт уже используется, возвращается ошибка.
+// В журнал записывается информация о попытке, успешной блокировке
+// и отказе в случае занятости.
+func LockAccount(accountID int) error {
+	log.Printf("[MUTEX] попытка блокировки аккаунта %d", accountID)
+
+	globalMu.Lock()
+	lock, ok := accountLocks[accountID]
+	if !ok {
+		lock = &sync.Mutex{}
+		accountLocks[accountID] = lock
+	}
+	globalMu.Unlock()
+
+	if !lock.TryLock() {
+		log.Printf("[MUTEX] аккаунт %d занят", accountID)
+		return fmt.Errorf("аккаунт %d уже используется", accountID)
+	}
+
+	log.Printf("[MUTEX] аккаунт %d заблокирован", accountID)
+	return nil
+}
+
+// UnlockAccount освобождает мьютекс для указанного аккаунта
+// и записывает это событие в журнал.
+func UnlockAccount(accountID int) {
+	globalMu.Lock()
+	lock := accountLocks[accountID]
+	globalMu.Unlock()
+	if lock != nil {
+		lock.Unlock()
+		log.Printf("[MUTEX] аккаунт %d разблокирован", accountID)
+	}
+}

--- a/pkg/telegram/comment.go
+++ b/pkg/telegram/comment.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"time"
 
+	accountmutex "atg_go/internal/module/account_mutex"
 	"atg_go/models"
 	"atg_go/pkg/storage"
 	module "atg_go/pkg/telegram/module"
@@ -22,6 +23,13 @@ import (
 // При неудаче оба идентификатора равны 0.
 func SendComment(db *storage.DB, accountID int, phone, channelURL string, apiID int, apiHash string, postsCount int, canSend func(channelID, messageID int) (bool, error), userIDs []int, proxy *models.Proxy) (int, int, error) {
 	log.Printf("[START] Отправка эмодзи в канал %s от имени %s", channelURL, phone)
+
+	// Блокируем аккаунт, чтобы избежать параллельного использования
+	if err := accountmutex.LockAccount(accountID); err != nil {
+		return 0, 0, err
+	}
+	// Гарантируем освобождение мьютекса после завершения работы
+	defer accountmutex.UnlockAccount(accountID)
 
 	// Извлекаем username из URL канала (например, из "https://t.me/channel" извлекаем "channel")
 	username, err := module.Modf_ExtractUsername(channelURL)

--- a/pkg/telegram/reaction.go
+++ b/pkg/telegram/reaction.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"time"
 
+	accountmutex "atg_go/internal/module/account_mutex"
 	"atg_go/models"
 	"atg_go/pkg/storage"
 	module "atg_go/pkg/telegram/module"
@@ -22,6 +23,13 @@ import (
 // ошибку. При неудаче оба идентификатора равны 0.
 func SendReaction(db *storage.DB, accountID int, phone, channelURL string, apiID int, apiHash string, msgCount int, proxy *models.Proxy) (int, int, error) {
 	log.Printf("[START] Отправка реакции в канал %s от имени %s", channelURL, phone)
+
+	// Захватываем мьютекс для аккаунта, чтобы исключить параллельное использование
+	if err := accountmutex.LockAccount(accountID); err != nil {
+		return 0, 0, err
+	}
+	// Освобождаем мьютекс по завершении работы
+	defer accountmutex.UnlockAccount(accountID)
 
 	username, err := module.Modf_ExtractUsername(channelURL)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Перенесён мьютекс аккаунтов в `internal/module/account_mutex` и удалён старый каталог `account_deadlock`
- Обработчики комментариев и реакций используют `internal/module/account_mutex` для эксклюзивного доступа к аккаунтам

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689da3879e848327a5b9bdbd78586fc7