### PR TITLE
feat: add dispatcher activity cancel endpoint

### DIFF
--- a/internal/module/routes.go
+++ b/internal/module/routes.go
@@ -10,5 +10,6 @@ import (
 func SetupRoutes(r *gin.RouterGroup, db *storage.DB) {
 	handler := NewHandler(db)
 	r.POST("/dispatcher_activity", handler.DispatcherActivity)
+	r.POST("/dispatcher_activity/cancel_all", handler.CancelAllDispatcherActivity)
 	r.POST("/unsubscribe", handler.Unsubscribe)
 }


### PR DESCRIPTION
## Summary
- add cancellation support to dispatcher activity module
- allow server to cancel all running dispatcher activity tasks via new endpoint
- track running dispatcher activity tasks in handler

## Testing
- `go test ./...` *(fails: command did not complete)*
- `go build ./internal/module` *(fails: command did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_689e4682191483279305d1cee7dba0a4