### PR TITLE
feat: add statistics collection

### DIFF
--- a/internal/statistics/handler.go
+++ b/internal/statistics/handler.go
@@ -1,0 +1,31 @@
+package statistics
+
+import (
+	"atg_go/pkg/storage"
+	stats "atg_go/pkg/telegram/statistics"
+	"log"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler обслуживает HTTP-запросы, связанные со статистикой.
+type Handler struct {
+	DB *storage.DB
+}
+
+// NewHandler создаёт новый обработчик статистики.
+func NewHandler(db *storage.DB) *Handler {
+	return &Handler{DB: db}
+}
+
+// Collect рассчитывает показатели и сохраняет их в таблицу statistics.
+func (h *Handler) Collect(c *gin.Context) {
+	stat, err := stats.Calculate(h.DB)
+	if err != nil {
+		log.Printf("[HANDLER ERROR] не удалось посчитать статистику: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "не удалось посчитать статистику"})
+		return
+	}
+	c.JSON(http.StatusOK, stat)
+}

--- a/internal/statistics/routes.go
+++ b/internal/statistics/routes.go
@@ -1,0 +1,13 @@
+package statistics
+
+import (
+	"atg_go/pkg/storage"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SetupRoutes регистрирует маршруты статистики.
+func SetupRoutes(r *gin.RouterGroup, db *storage.DB) {
+	handler := NewHandler(db)
+	r.POST("/collect", handler.Collect)
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"atg_go/internal/middleware"
 	module "atg_go/internal/module"
 	reaction "atg_go/internal/reaction"
+	statistics "atg_go/internal/statistics"
 	"atg_go/pkg/storage"
 	"database/sql"
 	"log"
@@ -76,6 +77,10 @@ func setupRouter(db *storage.DB, commentDB *storage.CommentDB) *gin.Engine {
 	// Группа роутов для telegram-модуля
 	moduleGroup := r.Group("/module")
 	module.SetupRoutes(moduleGroup, db)
+
+	// Группа роутов для статистики
+	statsGroup := r.Group("/statistics")
+	statistics.SetupRoutes(statsGroup, db)
 
 	// Health check endpoint
 	r.GET("/health", func(c *gin.Context) {

--- a/migrations/tables.sql
+++ b/migrations/tables.sql
@@ -80,3 +80,13 @@ CREATE TABLE IF NOT EXISTS account_session (
     account INTEGER NOT NULL UNIQUE REFERENCES accounts(id) ON DELETE CASCADE,
     data_json TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS statistics (
+    id SERIAL PRIMARY KEY,
+    stat_date DATE NOT NULL UNIQUE,             -- Дата, за которую рассчитана статистика (по времени Москвы)
+    comment_mean DOUBLE PRECISION NOT NULL,
+    reaction_mean DOUBLE PRECISION NOT NULL,
+    account_floodban INTEGER NOT NULL,
+    account_all INTEGER NOT NULL
+);
+

--- a/models/statistics.go
+++ b/models/statistics.go
@@ -1,0 +1,13 @@
+package models
+
+import "time"
+
+// Statistics отражает запись таблицы statistics с агрегированными данными за конкретную дату.
+type Statistics struct {
+	ID              int       `json:"id"`
+	Date            time.Time `json:"date"`             // Дата, за которую собрана статистика
+	CommentMean     float64   `json:"comment_mean"`     // Среднее количество комментариев на аккаунт
+	ReactionMean    float64   `json:"reaction_mean"`    // Среднее количество реакций на аккаунт
+	AccountFloodBan int       `json:"account_floodban"` // Количество аккаунтов во флуд-бане
+	AccountAll      int       `json:"account_all"`      // Всего авторизованных аккаунтов
+}

--- a/pkg/telegram/statistics/floodban.go
+++ b/pkg/telegram/statistics/floodban.go
@@ -1,0 +1,12 @@
+package statistics
+
+import (
+	"atg_go/pkg/storage"
+	"time"
+)
+
+// MarkFloodBan фиксирует время окончания флуд-бана для аккаунта.
+func MarkFloodBan(db *storage.DB, accountID int, until time.Time) error {
+	_, err := db.Conn.Exec("UPDATE accounts SET floodwait_until = $1 WHERE id = $2", until, accountID)
+	return err
+}

--- a/pkg/telegram/statistics/statistics.go
+++ b/pkg/telegram/statistics/statistics.go
@@ -1,0 +1,71 @@
+package statistics
+
+import (
+	"atg_go/models"
+	"atg_go/pkg/storage"
+	"time"
+)
+
+// Calculate вычисляет статистику по базе и сохраняет её в таблицу statistics.
+func Calculate(db *storage.DB) (*models.Statistics, error) {
+	var stat models.Statistics
+
+	// Загружаем часовой пояс Москвы
+	loc, err := time.LoadLocation("Europe/Moscow")
+	if err != nil {
+		return nil, err
+	}
+
+	// Определяем начало и конец текущих суток по московскому времени
+	now := time.Now().In(loc)
+	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
+	dayEnd := dayStart.Add(24 * time.Hour)
+	stat.Date = dayStart
+
+	// Количество авторизованных аккаунтов
+	if err := db.Conn.QueryRow("SELECT COUNT(*) FROM accounts WHERE is_authorized = true").Scan(&stat.AccountAll); err != nil {
+		return nil, err
+	}
+
+	// Общее количество комментариев за текущие сутки
+	var commentCount int
+	if err := db.Conn.QueryRow(
+		"SELECT COUNT(*) FROM activity WHERE activity_type = 'comment' AND date_time >= $1 AND date_time < $2",
+		dayStart.UTC(), dayEnd.UTC(),
+	).Scan(&commentCount); err != nil {
+		return nil, err
+	}
+
+	// Общее количество реакций за текущие сутки
+	var reactionCount int
+	if err := db.Conn.QueryRow(
+		"SELECT COUNT(*) FROM activity WHERE activity_type = 'reaction' AND date_time >= $1 AND date_time < $2",
+		dayStart.UTC(), dayEnd.UTC(),
+	).Scan(&reactionCount); err != nil {
+		return nil, err
+	}
+
+	// Количество аккаунтов, находящихся во флуд-бане
+	if err := db.Conn.QueryRow("SELECT COUNT(*) FROM accounts WHERE floodwait_until IS NOT NULL AND floodwait_until > NOW()").Scan(&stat.AccountFloodBan); err != nil {
+		return nil, err
+	}
+
+	// Расчёт средних значений
+	if stat.AccountAll > 0 {
+		stat.CommentMean = float64(commentCount) / float64(stat.AccountAll)
+		stat.ReactionMean = float64(reactionCount) / float64(stat.AccountAll)
+	}
+
+	// Сохраняем или обновляем запись в таблице statistics для текущей даты
+	err = db.Conn.QueryRow(
+		"INSERT INTO statistics (stat_date, comment_mean, reaction_mean, account_floodban, account_all) VALUES ($1, $2, $3, $4, $5) "+
+			"ON CONFLICT (stat_date) DO UPDATE SET comment_mean = EXCLUDED.comment_mean, reaction_mean = EXCLUDED.reaction_mean, account_floodban = EXCLUDED.account_floodban, account_all = EXCLUDED.account_all "+
+			"RETURNING id, stat_date",
+		stat.Date, stat.CommentMean, stat.ReactionMean, stat.AccountFloodBan, stat.AccountAll,
+	).Scan(&stat.ID, &stat.Date)
+	if err != nil {
+		return nil, err
+	}
+
+	return &stat, nil
+}


### PR DESCRIPTION
## Summary
- store per-day statistics with `stat_date`
- compute today's statistics in Moscow timezone and upsert daily record

## Testing
- `go test ./...` *(hangs)*

------
https://chatgpt.com/codex/tasks/task_e_689e5bfcecb8832793e9e861965ecb8b