### PR TITLE
Добавление системы заказов и привязки аккаунтов

### DIFF
--- a/internal/order/handler.go
+++ b/internal/order/handler.go
@@ -1,0 +1,60 @@
+package order
+
+import (
+	"log"
+	"strconv"
+
+	"atg_go/models"
+	"atg_go/pkg/storage"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler обрабатывает HTTP-запросы, связанные с заказами
+// Комментарии на русском языке по требованию пользователя
+
+type Handler struct {
+	DB *storage.DB
+}
+
+// NewHandler создаёт новый экземпляр обработчика
+func NewHandler(db *storage.DB) *Handler {
+	return &Handler{DB: db}
+}
+
+// CreateOrder создаёт новый заказ и распределяет аккаунты
+func (h *Handler) CreateOrder(c *gin.Context) {
+	var o models.Order
+	if err := c.ShouldBindJSON(&o); err != nil {
+		c.JSON(400, gin.H{"error": "invalid data"})
+		return
+	}
+
+	created, err := h.DB.CreateOrder(o)
+	if err != nil {
+		log.Printf("[ERROR] не удалось создать заказ: %v", err)
+		c.JSON(500, gin.H{"error": "db error"})
+		return
+	}
+
+	c.JSON(200, created)
+}
+
+// UpdateAccountsNumber изменяет количество аккаунтов для заказа
+func (h *Handler) UpdateAccountsNumber(c *gin.Context) {
+	id, _ := strconv.Atoi(c.Param("id"))
+	var input struct {
+		AccountsNumberTheory int `json:"accounts_number_theory"`
+	}
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(400, gin.H{"error": "invalid data"})
+		return
+	}
+	updated, err := h.DB.UpdateOrderAccountsNumber(id, input.AccountsNumberTheory)
+	if err != nil {
+		log.Printf("[ERROR] не удалось обновить заказ: %v", err)
+		c.JSON(500, gin.H{"error": "db error"})
+		return
+	}
+	c.JSON(200, updated)
+}

--- a/internal/order/routes.go
+++ b/internal/order/routes.go
@@ -1,0 +1,14 @@
+package order
+
+import (
+	"atg_go/pkg/storage"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SetupRoutes регистрирует маршруты для работы с заказами
+func SetupRoutes(r *gin.RouterGroup, db *storage.DB) {
+	h := NewHandler(db)
+	r.POST("/CreateOrder", h.CreateOrder)
+	r.POST("/UpdateAccounts/:id", h.UpdateAccountsNumber)
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"atg_go/internal/comments"
 	"atg_go/internal/middleware"
 	module "atg_go/internal/module"
+	orders "atg_go/internal/order"
 	reaction "atg_go/internal/reaction"
 	statistics "atg_go/internal/statistics"
 	"atg_go/pkg/storage"
@@ -77,6 +78,10 @@ func setupRouter(db *storage.DB, commentDB *storage.CommentDB) *gin.Engine {
 	// Группа роутов для telegram-модуля
 	moduleGroup := r.Group("/module")
 	module.SetupRoutes(moduleGroup, db)
+
+	// Группа роутов для заказов
+	orderGroup := r.Group("/order")
+	orders.SetupRoutes(orderGroup, db)
 
 	// Группа роутов для статистики
 	statsGroup := r.Group("/statistics")

--- a/migrations/tables.sql
+++ b/migrations/tables.sql
@@ -10,6 +10,16 @@ CREATE TABLE IF NOT EXISTS proxy (
     is_active BOOLEAN NULL
 );
 
+-- Таблица заказов на размещение ссылок
+CREATE TABLE IF NOT EXISTS orders (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    url TEXT NOT NULL,
+    accounts_number_theory INTEGER NOT NULL,
+    accounts_number_fact INTEGER NOT NULL DEFAULT 0,
+    date_time TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
 -- Основная таблица аккаунтов Telegram
 CREATE TABLE IF NOT EXISTS accounts (
     id SERIAL PRIMARY KEY,                           -- Уникальный идентификатор аккаунта
@@ -19,7 +29,8 @@ CREATE TABLE IF NOT EXISTS accounts (
     is_authorized BOOLEAN DEFAULT false,             -- Флаг успешной авторизации
     phone_code_hash TEXT,                            -- Хэш кода подтверждения из Telegram
     floodwait_until TIMESTAMP NULL,                 -- Время окончания флуд-бана (NULL если нет блокировки)
-    proxy_id INTEGER REFERENCES proxy(id)           -- Привязка к прокси
+    proxy_id INTEGER REFERENCES proxy(id),          -- Привязка к прокси
+    order_id INTEGER REFERENCES orders(id)          -- Заказ, который сейчас выполняет аккаунт
 );
 
 -- Триггер для автоматического обновления account_count

--- a/models/account.go
+++ b/models/account.go
@@ -8,5 +8,6 @@ type Account struct {
 	IsAuthorized  bool   `json:"is_authorized"`
 	PhoneCodeHash string `json:"phone_code_hash"`
 	ProxyID       *int   `json:"proxy_id"`
+	OrderID       *int   `json:"order_id"` // ID выполняемого заказа (NULL, если аккаунт свободен)
 	Proxy         *Proxy `json:"proxy"`
 }

--- a/models/order.go
+++ b/models/order.go
@@ -1,0 +1,21 @@
+package models
+
+import "time"
+
+// Order описывает заказ на размещение ссылки в описании аккаунтов
+// name - произвольное название заказа
+// url - ссылка на канал
+// accounts_number_theory - желаемое количество аккаунтов
+// accounts_number_fact - количество фактически задействованных аккаунтов
+// date_time - время создания заказа
+//
+// Комментарии в коде на русском языке по требованию пользователя
+
+type Order struct {
+	ID                   int       `json:"id"`
+	Name                 string    `json:"name"`
+	URL                  string    `json:"url"`
+	AccountsNumberTheory int       `json:"accounts_number_theory"`
+	AccountsNumberFact   int       `json:"accounts_number_fact"`
+	DateTime             time.Time `json:"date_time"`
+}

--- a/pkg/storage/order.go
+++ b/pkg/storage/order.go
@@ -1,0 +1,136 @@
+package storage
+
+import (
+	"atg_go/models"
+	"database/sql"
+	"log"
+)
+
+// CreateOrder создаёт заказ и распределяет свободные аккаунты
+func (db *DB) CreateOrder(o models.Order) (*models.Order, error) {
+	tx, err := db.Conn.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	// Вставляем запись о заказе
+	err = tx.QueryRow(
+		`INSERT INTO orders (name, url, accounts_number_theory) VALUES ($1, $2, $3) RETURNING id, accounts_number_fact, date_time`,
+		o.Name, o.URL, o.AccountsNumberTheory,
+	).Scan(&o.ID, &o.AccountsNumberFact, &o.DateTime)
+	if err != nil {
+		return nil, err
+	}
+
+	// Выбираем свободные аккаунты в случайном порядке
+	rows, err := tx.Query(
+		`SELECT id FROM accounts WHERE order_id IS NULL ORDER BY RANDOM() LIMIT $1`,
+		o.AccountsNumberTheory,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		if _, err := tx.Exec(`UPDATE accounts SET order_id = $1 WHERE id = $2`, o.ID, id); err != nil {
+			return nil, err
+		}
+		count++
+	}
+
+	o.AccountsNumberFact = count
+	if _, err := tx.Exec(`UPDATE orders SET accounts_number_fact = $1 WHERE id = $2`, o.AccountsNumberFact, o.ID); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	log.Printf("[DB INFO] Создан заказ %d, аккаунтов назначено: %d", o.ID, o.AccountsNumberFact)
+	return &o, nil
+}
+
+// UpdateOrderAccountsNumber изменяет количество аккаунтов в заказе
+func (db *DB) UpdateOrderAccountsNumber(orderID, newNumber int) (*models.Order, error) {
+	tx, err := db.Conn.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	var o models.Order
+	err = tx.QueryRow(
+		`SELECT id, name, url, accounts_number_theory, accounts_number_fact, date_time FROM orders WHERE id = $1`,
+		orderID,
+	).Scan(&o.ID, &o.Name, &o.URL, &o.AccountsNumberTheory, &o.AccountsNumberFact, &o.DateTime)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, err
+		}
+		return nil, err
+	}
+
+	if _, err := tx.Exec(`UPDATE orders SET accounts_number_theory = $1 WHERE id = $2`, newNumber, orderID); err != nil {
+		return nil, err
+	}
+	o.AccountsNumberTheory = newNumber
+
+	if newNumber > o.AccountsNumberFact {
+		// Добавляем недостающие аккаунты
+		diff := newNumber - o.AccountsNumberFact
+		rows, err := tx.Query(`SELECT id FROM accounts WHERE order_id IS NULL ORDER BY RANDOM() LIMIT $1`, diff)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		added := 0
+		for rows.Next() {
+			var id int
+			if err := rows.Scan(&id); err != nil {
+				return nil, err
+			}
+			if _, err := tx.Exec(`UPDATE accounts SET order_id = $1 WHERE id = $2`, orderID, id); err != nil {
+				return nil, err
+			}
+			added++
+		}
+		o.AccountsNumberFact += added
+	} else if newNumber < o.AccountsNumberFact {
+		// Освобождаем лишние аккаунты
+		diff := o.AccountsNumberFact - newNumber
+		rows, err := tx.Query(`SELECT id FROM accounts WHERE order_id = $1 ORDER BY RANDOM() LIMIT $2`, orderID, diff)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		removed := 0
+		for rows.Next() {
+			var id int
+			if err := rows.Scan(&id); err != nil {
+				return nil, err
+			}
+			if _, err := tx.Exec(`UPDATE accounts SET order_id = NULL WHERE id = $1`, id); err != nil {
+				return nil, err
+			}
+			removed++
+		}
+		o.AccountsNumberFact -= removed
+	}
+
+	if _, err := tx.Exec(`UPDATE orders SET accounts_number_fact = $1 WHERE id = $2`, o.AccountsNumberFact, orderID); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	log.Printf("[DB INFO] Заказ %d обновлён, фактических аккаунтов: %d", o.ID, o.AccountsNumberFact)
+	return &o, nil
+}


### PR DESCRIPTION
## Summary
- создать таблицу orders и поле order_id в accounts
- реализовать логику распределения аккаунтов по заказам и изменение их количества
- добавить HTTP‑эндпоинты и маршруты для управления заказами

## Testing
- `go test ./...`
- `go vet ./...` *(зависло, прервано)*

------
https://chatgpt.com/codex/tasks/task_e_689f00b019b083278ff757de3c2f1d19