### PR TITLE
Добавление системы заказов и привязки аккаунтов

### DIFF
--- a/internal/module/handler.go
+++ b/internal/module/handler.go
@@ -123,3 +123,12 @@ func (h *Handler) Unsubscribe(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "completed"})
 }
+
+// OrderLinkUpdate обрабатывает запрос на обновление ссылок в описании аккаунтов
+func (h *Handler) OrderLinkUpdate(c *gin.Context) {
+	if err := telegrammodule.Modf_OrderLinkUpdate(h.DB); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "links updated"})
+}

--- a/internal/module/routes.go
+++ b/internal/module/routes.go
@@ -12,4 +12,5 @@ func SetupRoutes(r *gin.RouterGroup, db *storage.DB) {
 	r.POST("/dispatcher_activity", handler.DispatcherActivity)
 	r.POST("/dispatcher_activity/cancel_all", handler.CancelAllDispatcherActivity)
 	r.POST("/unsubscribe", handler.Unsubscribe)
+	r.POST("/order/link_updat", handler.OrderLinkUpdate)
 }

--- a/internal/order/handler.go
+++ b/internal/order/handler.go
@@ -1,0 +1,60 @@
+package order
+
+import (
+	"log"
+	"strconv"
+
+	"atg_go/models"
+	"atg_go/pkg/storage"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler обрабатывает HTTP-запросы, связанные с заказами
+// Комментарии на русском языке по требованию пользователя
+
+type Handler struct {
+	DB *storage.DB
+}
+
+// NewHandler создаёт новый экземпляр обработчика
+func NewHandler(db *storage.DB) *Handler {
+	return &Handler{DB: db}
+}
+
+// CreateOrder создаёт новый заказ и распределяет аккаунты
+func (h *Handler) CreateOrder(c *gin.Context) {
+	var o models.Order
+	if err := c.ShouldBindJSON(&o); err != nil {
+		c.JSON(400, gin.H{"error": "invalid data"})
+		return
+	}
+
+	created, err := h.DB.CreateOrder(o)
+	if err != nil {
+		log.Printf("[ERROR] не удалось создать заказ: %v", err)
+		c.JSON(500, gin.H{"error": "db error"})
+		return
+	}
+
+	c.JSON(200, created)
+}
+
+// UpdateAccountsNumber изменяет количество аккаунтов для заказа
+func (h *Handler) UpdateAccountsNumber(c *gin.Context) {
+	id, _ := strconv.Atoi(c.Param("id"))
+	var input struct {
+		AccountsNumberTheory int `json:"accounts_number_theory"`
+	}
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(400, gin.H{"error": "invalid data"})
+		return
+	}
+	updated, err := h.DB.UpdateOrderAccountsNumber(id, input.AccountsNumberTheory)
+	if err != nil {
+		log.Printf("[ERROR] не удалось обновить заказ: %v", err)
+		c.JSON(500, gin.H{"error": "db error"})
+		return
+	}
+	c.JSON(200, updated)
+}

--- a/internal/order/routes.go
+++ b/internal/order/routes.go
@@ -1,0 +1,14 @@
+package order
+
+import (
+	"atg_go/pkg/storage"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SetupRoutes регистрирует маршруты для работы с заказами
+func SetupRoutes(r *gin.RouterGroup, db *storage.DB) {
+	h := NewHandler(db)
+	r.POST("/CreateOrder", h.CreateOrder)
+	r.POST("/UpdateAccounts/:id", h.UpdateAccountsNumber)
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"atg_go/internal/comments"
 	"atg_go/internal/middleware"
 	module "atg_go/internal/module"
+	orders "atg_go/internal/order"
 	reaction "atg_go/internal/reaction"
 	statistics "atg_go/internal/statistics"
 	"atg_go/pkg/storage"
@@ -77,6 +78,10 @@ func setupRouter(db *storage.DB, commentDB *storage.CommentDB) *gin.Engine {
 	// Группа роутов для telegram-модуля
 	moduleGroup := r.Group("/module")
 	module.SetupRoutes(moduleGroup, db)
+
+	// Группа роутов для заказов
+	orderGroup := r.Group("/order")
+	orders.SetupRoutes(orderGroup, db)
 
 	// Группа роутов для статистики
 	statsGroup := r.Group("/statistics")

--- a/migrations/orders.sql
+++ b/migrations/orders.sql
@@ -1,0 +1,51 @@
+-- Таблица заказов на размещение ссылок
+CREATE TABLE IF NOT EXISTS orders (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    url TEXT NOT NULL,
+    accounts_number_theory INTEGER NOT NULL,
+    accounts_number_fact INTEGER NOT NULL DEFAULT 0,
+    date_time TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Добавление поля order_id в таблицу accounts
+ALTER TABLE accounts
+    ADD COLUMN IF NOT EXISTS order_id INTEGER REFERENCES orders(id);
+
+-- Функция для автоматического обновления количества фактических аккаунтов
+CREATE OR REPLACE FUNCTION update_order_accounts_number() RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.order_id IS NOT NULL THEN
+            UPDATE orders SET accounts_number_fact = accounts_number_fact + 1 WHERE id = NEW.order_id;
+        END IF;
+        RETURN NEW;
+    ELSIF TG_OP = 'UPDATE' THEN
+        IF OLD.order_id IS NOT DISTINCT FROM NEW.order_id THEN
+            RETURN NEW;
+        END IF;
+        IF OLD.order_id IS NOT NULL THEN
+            UPDATE orders SET accounts_number_fact = accounts_number_fact - 1 WHERE id = OLD.order_id;
+        END IF;
+        IF NEW.order_id IS NOT NULL THEN
+            UPDATE orders SET accounts_number_fact = accounts_number_fact + 1 WHERE id = NEW.order_id;
+        END IF;
+        RETURN NEW;
+    ELSIF TG_OP = 'DELETE' THEN
+        IF OLD.order_id IS NOT NULL THEN
+            UPDATE orders SET accounts_number_fact = accounts_number_fact - 1 WHERE id = OLD.order_id;
+        END IF;
+        RETURN OLD;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Триггеры на таблицу accounts
+CREATE TRIGGER accounts_order_insert AFTER INSERT ON accounts
+    FOR EACH ROW EXECUTE FUNCTION update_order_accounts_number();
+
+CREATE TRIGGER accounts_order_update AFTER UPDATE OF order_id ON accounts
+    FOR EACH ROW EXECUTE FUNCTION update_order_accounts_number();
+
+CREATE TRIGGER accounts_order_delete AFTER DELETE ON accounts
+    FOR EACH ROW EXECUTE FUNCTION update_order_accounts_number();

--- a/migrations/tables.sql
+++ b/migrations/tables.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS accounts (
     is_authorized BOOLEAN DEFAULT false,             -- Флаг успешной авторизации
     phone_code_hash TEXT,                            -- Хэш кода подтверждения из Telegram
     floodwait_until TIMESTAMP NULL,                 -- Время окончания флуд-бана (NULL если нет блокировки)
-    proxy_id INTEGER REFERENCES proxy(id)           -- Привязка к прокси
+    proxy_id INTEGER REFERENCES proxy(id)          -- Привязка к прокси
 );
 
 -- Триггер для автоматического обновления account_count

--- a/models/account.go
+++ b/models/account.go
@@ -8,5 +8,6 @@ type Account struct {
 	IsAuthorized  bool   `json:"is_authorized"`
 	PhoneCodeHash string `json:"phone_code_hash"`
 	ProxyID       *int   `json:"proxy_id"`
+	OrderID       *int   `json:"order_id"` // ID выполняемого заказа (NULL, если аккаунт свободен)
 	Proxy         *Proxy `json:"proxy"`
 }

--- a/models/order.go
+++ b/models/order.go
@@ -1,0 +1,21 @@
+package models
+
+import "time"
+
+// Order описывает заказ на размещение ссылки в описании аккаунтов
+// name - произвольное название заказа
+// url - ссылка на канал
+// accounts_number_theory - желаемое количество аккаунтов
+// accounts_number_fact - количество фактически задействованных аккаунтов
+// date_time - время создания заказа
+//
+// Комментарии в коде на русском языке по требованию пользователя
+
+type Order struct {
+	ID                   int       `json:"id"`
+	Name                 string    `json:"name"`
+	URL                  string    `json:"url"`
+	AccountsNumberTheory int       `json:"accounts_number_theory"`
+	AccountsNumberFact   int       `json:"accounts_number_fact"`
+	DateTime             time.Time `json:"date_time"`
+}

--- a/pkg/storage/order.go
+++ b/pkg/storage/order.go
@@ -1,0 +1,129 @@
+package storage
+
+import (
+	"atg_go/models"
+	"database/sql"
+	"log"
+)
+
+// CreateOrder создаёт заказ и распределяет свободные аккаунты
+func (db *DB) CreateOrder(o models.Order) (*models.Order, error) {
+	tx, err := db.Conn.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	// Вставляем запись о заказе
+	err = tx.QueryRow(
+		`INSERT INTO orders (name, url, accounts_number_theory) VALUES ($1, $2, $3) RETURNING id, accounts_number_fact, date_time`,
+		o.Name, o.URL, o.AccountsNumberTheory,
+	).Scan(&o.ID, &o.AccountsNumberFact, &o.DateTime)
+	if err != nil {
+		return nil, err
+	}
+
+	// Выбираем свободные аккаунты в случайном порядке
+	rows, err := tx.Query(
+		`SELECT id FROM accounts WHERE order_id IS NULL ORDER BY RANDOM() LIMIT $1`,
+		o.AccountsNumberTheory,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		if _, err := tx.Exec(`UPDATE accounts SET order_id = $1 WHERE id = $2`, o.ID, id); err != nil {
+			return nil, err
+		}
+		count++
+	}
+
+	o.AccountsNumberFact = count
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	log.Printf("[DB INFO] Создан заказ %d, аккаунтов назначено: %d", o.ID, o.AccountsNumberFact)
+	return &o, nil
+}
+
+// UpdateOrderAccountsNumber изменяет количество аккаунтов в заказе
+func (db *DB) UpdateOrderAccountsNumber(orderID, newNumber int) (*models.Order, error) {
+	tx, err := db.Conn.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	var o models.Order
+	err = tx.QueryRow(
+		`SELECT id, name, url, accounts_number_theory, accounts_number_fact, date_time FROM orders WHERE id = $1`,
+		orderID,
+	).Scan(&o.ID, &o.Name, &o.URL, &o.AccountsNumberTheory, &o.AccountsNumberFact, &o.DateTime)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, err
+		}
+		return nil, err
+	}
+
+	if _, err := tx.Exec(`UPDATE orders SET accounts_number_theory = $1 WHERE id = $2`, newNumber, orderID); err != nil {
+		return nil, err
+	}
+	o.AccountsNumberTheory = newNumber
+
+	if newNumber > o.AccountsNumberFact {
+		// Добавляем недостающие аккаунты
+		diff := newNumber - o.AccountsNumberFact
+		rows, err := tx.Query(`SELECT id FROM accounts WHERE order_id IS NULL ORDER BY RANDOM() LIMIT $1`, diff)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		added := 0
+		for rows.Next() {
+			var id int
+			if err := rows.Scan(&id); err != nil {
+				return nil, err
+			}
+			if _, err := tx.Exec(`UPDATE accounts SET order_id = $1 WHERE id = $2`, orderID, id); err != nil {
+				return nil, err
+			}
+			added++
+		}
+		o.AccountsNumberFact += added
+	} else if newNumber < o.AccountsNumberFact {
+		// Освобождаем лишние аккаунты
+		diff := o.AccountsNumberFact - newNumber
+		rows, err := tx.Query(`SELECT id FROM accounts WHERE order_id = $1 ORDER BY RANDOM() LIMIT $2`, orderID, diff)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		removed := 0
+		for rows.Next() {
+			var id int
+			if err := rows.Scan(&id); err != nil {
+				return nil, err
+			}
+			if _, err := tx.Exec(`UPDATE accounts SET order_id = NULL WHERE id = $1`, id); err != nil {
+				return nil, err
+			}
+			removed++
+		}
+		o.AccountsNumberFact -= removed
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	log.Printf("[DB INFO] Заказ %d обновлён, фактических аккаунтов: %d", o.ID, o.AccountsNumberFact)
+	return &o, nil
+}

--- a/pkg/storage/order.go
+++ b/pkg/storage/order.go
@@ -127,3 +127,17 @@ func (db *DB) UpdateOrderAccountsNumber(orderID, newNumber int) (*models.Order, 
 	log.Printf("[DB INFO] Заказ %d обновлён, фактических аккаунтов: %d", o.ID, o.AccountsNumberFact)
 	return &o, nil
 }
+
+// GetOrderByID возвращает заказ по его идентификатору
+// Используется для получения ссылки при обновлении описаний аккаунтов
+func (db *DB) GetOrderByID(id int) (*models.Order, error) {
+	var o models.Order
+	err := db.Conn.QueryRow(
+		`SELECT id, name, url, accounts_number_theory, accounts_number_fact, date_time FROM orders WHERE id = $1`,
+		id,
+	).Scan(&o.ID, &o.Name, &o.URL, &o.AccountsNumberTheory, &o.AccountsNumberFact, &o.DateTime)
+	if err != nil {
+		return nil, err
+	}
+	return &o, nil
+}

--- a/pkg/telegram/module/link_update.go
+++ b/pkg/telegram/module/link_update.go
@@ -1,0 +1,67 @@
+package module
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"atg_go/models"
+	"atg_go/pkg/storage"
+	accountmutex "atg_go/pkg/telegram/module/account_mutex"
+
+	"github.com/gotd/td/tg"
+)
+
+// Modf_OrderLinkUpdate обновляет описание у всех аккаунтов согласно их order_id
+// Если order_id есть, в описание ставится ссылка из соответствующего заказа,
+// иначе описание очищается. Комментарии на русском языке по требованию пользователя.
+func Modf_OrderLinkUpdate(db *storage.DB) error {
+	// Получаем все авторизованные аккаунты
+	accounts, err := db.GetAuthorizedAccounts()
+	if err != nil {
+		return err
+	}
+
+	for _, acc := range accounts {
+		var link string
+		if acc.OrderID != nil {
+			// Получаем URL заказа
+			order, err := db.GetOrderByID(*acc.OrderID)
+			if err != nil {
+				log.Printf("[ERROR] не удалось получить заказ %d: %v", *acc.OrderID, err)
+				continue
+			}
+			link = order.URL
+		}
+		if err := updateAccountLink(db, acc, link); err != nil {
+			log.Printf("[ERROR] аккаунт %d: %v", acc.ID, err)
+		}
+	}
+	return nil
+}
+
+// updateAccountLink устанавливает новое описание (about) для аккаунта
+func updateAccountLink(db *storage.DB, acc models.Account, link string) error {
+	// Блокируем аккаунт, чтобы не выполнять параллельные операции
+	if err := accountmutex.LockAccount(acc.ID); err != nil {
+		return err
+	}
+	defer accountmutex.UnlockAccount(acc.ID)
+
+	// Инициализируем клиента Telegram
+	client, err := Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	return client.Run(ctx, func(ctx context.Context) error {
+		api := tg.NewClient(client)
+		// Используем переменную, чтобы получить указатель на строку
+		about := link
+		_, err := api.AccountUpdateProfile(ctx, &tg.AccountUpdateProfileRequest{About: &about})
+		return err
+	})
+}


### PR DESCRIPTION
## Summary
- создать таблицу orders и поле order_id в accounts
- реализовать логику распределения аккаунтов по заказам и изменение их количества
- добавить HTTP‑эндпоинты и маршруты для управления заказами
- вынести SQL‑миграции заказов в отдельный файл с триггерами автообновления счётчика

## Testing
- `go test ./...` *(команда зависла, прервана)*
- `go vet ./...` *(команда зависла, прервана)*

------
https://chatgpt.com/codex/tasks/task_e_689f00b019b083278ff757de3c2f1d19