### PR TITLE
Добавление поля url_default в таблице orders

### DIFF
--- a/migrations/orders.sql
+++ b/migrations/orders.sql
@@ -2,7 +2,8 @@
 CREATE TABLE IF NOT EXISTS orders (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
-    url TEXT NOT NULL,
+    url_description TEXT NOT NULL, -- ссылка для описания аккаунта
+    url_default TEXT NOT NULL, -- ссылка по умолчанию
     accounts_number_theory INTEGER NOT NULL,
     accounts_number_fact INTEGER NOT NULL DEFAULT 0,
     date_time TIMESTAMP NOT NULL DEFAULT NOW()

--- a/migrations/tables.sql
+++ b/migrations/tables.sql
@@ -14,7 +14,8 @@ CREATE TABLE IF NOT EXISTS proxy (
 CREATE TABLE IF NOT EXISTS orders (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
-    url TEXT NOT NULL,
+    url_description TEXT NOT NULL, -- ссылка для описания аккаунта
+    url_default TEXT NOT NULL, -- ссылка по умолчанию
     accounts_number_theory INTEGER NOT NULL,
     accounts_number_fact INTEGER NOT NULL DEFAULT 0,
     date_time TIMESTAMP NOT NULL DEFAULT NOW()

--- a/models/order.go
+++ b/models/order.go
@@ -4,7 +4,8 @@ import "time"
 
 // Order описывает заказ на размещение ссылки в описании аккаунтов
 // name - произвольное название заказа
-// url - ссылка на канал
+// url_description - ссылка, которая будет вставлена в описание аккаунта
+// url_default - ссылка по умолчанию, которая хранится в заказе
 // accounts_number_theory - желаемое количество аккаунтов
 // accounts_number_fact - количество фактически задействованных аккаунтов
 // date_time - время создания заказа
@@ -14,7 +15,8 @@ import "time"
 type Order struct {
 	ID                   int       `json:"id"`
 	Name                 string    `json:"name"`
-	URL                  string    `json:"url"`
+	URLDescription       string    `json:"url_description"` // Текст ссылки для описания
+	URLDefault           string    `json:"url_default"`     // Ссылка по умолчанию
 	AccountsNumberTheory int       `json:"accounts_number_theory"`
 	AccountsNumberFact   int       `json:"accounts_number_fact"`
 	DateTime             time.Time `json:"date_time"`

--- a/pkg/storage/order.go
+++ b/pkg/storage/order.go
@@ -14,10 +14,10 @@ func (db *DB) CreateOrder(o models.Order) (*models.Order, error) {
 	}
 	defer tx.Rollback()
 
-	// Вставляем запись о заказе
+	// Вставляем запись о заказе вместе со ссылкой по умолчанию
 	err = tx.QueryRow(
-		`INSERT INTO orders (name, url, accounts_number_theory) VALUES ($1, $2, $3) RETURNING id, accounts_number_fact, date_time`,
-		o.Name, o.URL, o.AccountsNumberTheory,
+		`INSERT INTO orders (name, url_description, url_default, accounts_number_theory) VALUES ($1, $2, $3, $4) RETURNING id, accounts_number_fact, date_time`,
+		o.Name, o.URLDescription, o.URLDefault, o.AccountsNumberTheory, // передаём текст и ссылку по умолчанию
 	).Scan(&o.ID, &o.AccountsNumberFact, &o.DateTime)
 	if err != nil {
 		return nil, err
@@ -63,9 +63,9 @@ func (db *DB) UpdateOrderAccountsNumber(orderID, newNumber int) (*models.Order, 
 
 	var o models.Order
 	err = tx.QueryRow(
-		`SELECT id, name, url, accounts_number_theory, accounts_number_fact, date_time FROM orders WHERE id = $1`,
+		`SELECT id, name, url_description, url_default, accounts_number_theory, accounts_number_fact, date_time FROM orders WHERE id = $1`,
 		orderID,
-	).Scan(&o.ID, &o.Name, &o.URL, &o.AccountsNumberTheory, &o.AccountsNumberFact, &o.DateTime)
+	).Scan(&o.ID, &o.Name, &o.URLDescription, &o.URLDefault, &o.AccountsNumberTheory, &o.AccountsNumberFact, &o.DateTime) // читаем текст и ссылку по умолчанию
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, err
@@ -149,9 +149,9 @@ func (db *DB) UpdateOrderAccountsNumber(orderID, newNumber int) (*models.Order, 
 func (db *DB) GetOrderByID(id int) (*models.Order, error) {
 	var o models.Order
 	err := db.Conn.QueryRow(
-		`SELECT id, name, url, accounts_number_theory, accounts_number_fact, date_time FROM orders WHERE id = $1`,
+		`SELECT id, name, url_description, url_default, accounts_number_theory, accounts_number_fact, date_time FROM orders WHERE id = $1`,
 		id,
-	).Scan(&o.ID, &o.Name, &o.URL, &o.AccountsNumberTheory, &o.AccountsNumberFact, &o.DateTime)
+	).Scan(&o.ID, &o.Name, &o.URLDescription, &o.URLDefault, &o.AccountsNumberTheory, &o.AccountsNumberFact, &o.DateTime) // читаем текст и ссылку по умолчанию
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/telegram/module/link_update.go
+++ b/pkg/telegram/module/link_update.go
@@ -32,13 +32,13 @@ func Modf_OrderLinkUpdate(db *storage.DB) error {
 	for _, acc := range accounts {
 		var link string
 		if acc.OrderID != nil {
-			// Получаем URL заказа для подстановки в описание
+			// Получаем ссылку по умолчанию из заказа для подстановки в описание
 			order, err := db.GetOrderByID(*acc.OrderID)
 			if err != nil {
 				log.Printf("[LINK_UPDATE ERROR] заказ %d: %v", *acc.OrderID, err)
 				continue
 			}
-			link = order.URL
+			link = order.URLDefault
 		}
 		if err := updateAccountLink(db, acc, link); err != nil {
 			log.Printf("[LINK_UPDATE ERROR] аккаунт %d: %v", acc.ID, err)


### PR DESCRIPTION
## Summary
- добавлено поле `url_default` для хранения ссылки по умолчанию в заказе
- обновлены миграции, модель `Order`, хранилище и модуль обновления ссылок

## Testing
- `go test ./models`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a108e12b5483279724bc8047e26869