### PR TITLE
Исключение заказанных каналов из отписок

### DIFF
--- a/internal/module/handler.go
+++ b/internal/module/handler.go
@@ -31,10 +31,11 @@ func NewHandler(db *storage.DB) *Handler {
 // Ожидает JSON со списком activity_request, где у каждого запроса есть url и request_body.
 func (h *Handler) DispatcherActivity(c *gin.Context) {
 	var req struct {
-		DaysNumber       int                              `json:"days_number" binding:"required"`
-		ActivityRequest  []telegrammodule.ActivityRequest `json:"activity_request" binding:"required"`
-		ActivityComment  telegrammodule.ActivitySettings  `json:"activity_comment" binding:"required"`
-		ActivityReaction telegrammodule.ActivitySettings  `json:"activity_reaction" binding:"required"`
+		DaysNumber                  int                                `json:"days_number" binding:"required"`
+		ActivityRequest             []telegrammodule.ActivityRequest   `json:"activity_request" binding:"required"`
+		ActivityComment             telegrammodule.ActivitySettings    `json:"activity_comment" binding:"required"`
+		ActivityReaction            telegrammodule.ActivitySettings    `json:"activity_reaction" binding:"required"`
+		ActivityAccountsUnsubscribe telegrammodule.UnsubscribeSettings `json:"activity_accounts_unsubscribe" binding:"required"`
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -57,7 +58,7 @@ func (h *Handler) DispatcherActivity(c *gin.Context) {
 			delete(h.tasks, taskID)
 			h.mu.Unlock()
 		}()
-		telegrammodule.ModF_DispatcherActivity(ctx, req.DaysNumber, req.ActivityRequest, req.ActivityComment, req.ActivityReaction)
+		telegrammodule.ModF_DispatcherActivity(ctx, req.DaysNumber, req.ActivityRequest, req.ActivityComment, req.ActivityReaction, req.ActivityAccountsUnsubscribe)
 	}(id)
 
 	c.JSON(http.StatusOK, gin.H{"status": "запущено", "task_id": id})

--- a/migrations/orders.sql
+++ b/migrations/orders.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS orders (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
     url TEXT NOT NULL,
+    url_default TEXT,
     accounts_number_theory INTEGER NOT NULL,
     accounts_number_fact INTEGER NOT NULL DEFAULT 0,
     date_time TIMESTAMP NOT NULL DEFAULT NOW()

--- a/migrations/tables.sql
+++ b/migrations/tables.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS orders (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
     url TEXT NOT NULL,
+    url_default TEXT,
     accounts_number_theory INTEGER NOT NULL,
     accounts_number_fact INTEGER NOT NULL DEFAULT 0,
     date_time TIMESTAMP NOT NULL DEFAULT NOW()

--- a/models/order.go
+++ b/models/order.go
@@ -15,6 +15,7 @@ type Order struct {
 	ID                   int       `json:"id"`
 	Name                 string    `json:"name"`
 	URL                  string    `json:"url"`
+	URLDefault           string    `json:"url_default"` // ссылку из этого поля нельзя отписывать
 	AccountsNumberTheory int       `json:"accounts_number_theory"`
 	AccountsNumberFact   int       `json:"accounts_number_fact"`
 	DateTime             time.Time `json:"date_time"`

--- a/pkg/storage/order.go
+++ b/pkg/storage/order.go
@@ -6,6 +6,30 @@ import (
 	"log"
 )
 
+// GetOrdersDefaultURLs возвращает список ссылок, от которых нельзя отписываться
+func (db *DB) GetOrdersDefaultURLs() ([]string, error) {
+	rows, err := db.Conn.Query(`SELECT url_default FROM orders`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var urls []string
+	for rows.Next() {
+		var url sql.NullString
+		if err := rows.Scan(&url); err != nil {
+			return nil, err
+		}
+		if url.Valid {
+			urls = append(urls, url.String)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return urls, nil
+}
+
 // CreateOrder создаёт заказ и распределяет свободные аккаунты
 func (db *DB) CreateOrder(o models.Order) (*models.Order, error) {
 	tx, err := db.Conn.Begin()

--- a/pkg/telegram/module/dispatcher_activity.go
+++ b/pkg/telegram/module/dispatcher_activity.go
@@ -27,11 +27,19 @@ type ActivitySettings struct {
 	DispatcherPeriod      []string `json:"dispatcher_period"`
 }
 
+// UnsubscribeSettings описывает параметры запуска отписки аккаунтов.
+type UnsubscribeSettings struct {
+	DispatcherStart string `json:"dispatcher_start"`
+}
+
 // ModF_DispatcherActivity выполняет запросы активности в течение
 // заданного количества суток и реагирует на отмену контекста.
-func ModF_DispatcherActivity(ctx context.Context, daysNumber int, activities []ActivityRequest, commentCfg, reactionCfg ActivitySettings) {
+func ModF_DispatcherActivity(ctx context.Context, daysNumber int, activities []ActivityRequest, commentCfg, reactionCfg ActivitySettings, unsubscribeCfg UnsubscribeSettings) {
 	rand.Seed(time.Now().UnixNano())
 	start := time.Now()
+
+	// Загружаем часовую зону Москвы для использования в расписании отписки
+	loc, _ := time.LoadLocation("Europe/Moscow")
 
 	for day := 0; day < daysNumber; day++ {
 		select {
@@ -43,69 +51,159 @@ func ModF_DispatcherActivity(ctx context.Context, daysNumber int, activities []A
 		var wg sync.WaitGroup
 
 		for _, act := range activities {
-			var cfg ActivitySettings
+			// Определяем конфигурацию в зависимости от типа активности
 			switch {
 			case strings.Contains(act.URL, "comment"):
-				cfg = commentCfg
-			case strings.Contains(act.URL, "reaction"):
-				cfg = reactionCfg
-			default:
-				continue
-			}
-
-			if len(cfg.DispatcherActivityMax) != 2 || len(cfg.DispatcherPeriod) != 2 {
-				continue
-			}
-
-			wg.Add(1)
-			go func(act ActivityRequest, cfg ActivitySettings, offset int) {
-				defer wg.Done()
-
-				startTime, err1 := time.Parse("15:04", cfg.DispatcherPeriod[0])
-				endTime, err2 := time.Parse("15:04", cfg.DispatcherPeriod[1])
-				if err1 != nil || err2 != nil {
-					return
-				}
-				startMin := startTime.Hour()*60 + startTime.Minute()
-				endMin := endTime.Hour()*60 + endTime.Minute()
-				minAct := cfg.DispatcherActivityMax[0]
-				maxAct := cfg.DispatcherActivityMax[1]
-				if endMin <= startMin || maxAct < minAct {
-					return
+				cfg := commentCfg
+				if len(cfg.DispatcherActivityMax) != 2 || len(cfg.DispatcherPeriod) != 2 {
+					continue
 				}
 
-				count := rand.Intn(maxAct-minAct+1) + minAct
+				wg.Add(1)
+				go func(act ActivityRequest, cfg ActivitySettings, offset int) {
+					defer wg.Done()
 
-				currentDay := start.AddDate(0, 0, offset)
-				windowStart := time.Date(currentDay.Year(), currentDay.Month(), currentDay.Day(), startTime.Hour(), startTime.Minute(), 0, 0, time.Local)
-				duration := time.Duration(endMin-startMin) * time.Minute
-				interval := duration / time.Duration(count)
-
-				for i := 0; i < count; i++ {
-					select {
-					case <-ctx.Done():
+					// Парсим временные границы выполнения
+					startTime, err1 := time.Parse("15:04", cfg.DispatcherPeriod[0])
+					endTime, err2 := time.Parse("15:04", cfg.DispatcherPeriod[1])
+					if err1 != nil || err2 != nil {
 						return
-					default:
+					}
+					startMin := startTime.Hour()*60 + startTime.Minute()
+					endMin := endTime.Hour()*60 + endTime.Minute()
+					minAct := cfg.DispatcherActivityMax[0]
+					maxAct := cfg.DispatcherActivityMax[1]
+					if endMin <= startMin || maxAct < minAct {
+						return
 					}
 
-					t := windowStart.Add(interval * time.Duration(i))
-					if sleep := time.Until(t); sleep > 0 {
+					count := rand.Intn(maxAct-minAct+1) + minAct
+
+					currentDay := start.AddDate(0, 0, offset)
+					windowStart := time.Date(currentDay.Year(), currentDay.Month(), currentDay.Day(), startTime.Hour(), startTime.Minute(), 0, 0, time.Local)
+					duration := time.Duration(endMin-startMin) * time.Minute
+					interval := duration / time.Duration(count)
+
+					for i := 0; i < count; i++ {
+						select {
+						case <-ctx.Done():
+							return
+						default:
+						}
+
+						t := windowStart.Add(interval * time.Duration(i))
+						if sleep := time.Until(t); sleep > 0 {
+							select {
+							case <-time.After(sleep):
+							case <-ctx.Done():
+								return
+							}
+						}
+						payload, _ := json.Marshal(act.RequestBody)
+						req, err := http.NewRequestWithContext(ctx, "POST", act.URL, bytes.NewBuffer(payload))
+						if err != nil {
+							continue
+						}
+						req.Header.Set("Content-Type", "application/json")
+						req.Header.Set("Authorization", "Bearer "+bearerToken)
+						http.DefaultClient.Do(req)
+					}
+				}(act, cfg, day)
+			case strings.Contains(act.URL, "reaction"):
+				cfg := reactionCfg
+				if len(cfg.DispatcherActivityMax) != 2 || len(cfg.DispatcherPeriod) != 2 {
+					continue
+				}
+
+				wg.Add(1)
+				go func(act ActivityRequest, cfg ActivitySettings, offset int) {
+					defer wg.Done()
+
+					// Парсим временные границы выполнения
+					startTime, err1 := time.Parse("15:04", cfg.DispatcherPeriod[0])
+					endTime, err2 := time.Parse("15:04", cfg.DispatcherPeriod[1])
+					if err1 != nil || err2 != nil {
+						return
+					}
+					startMin := startTime.Hour()*60 + startTime.Minute()
+					endMin := endTime.Hour()*60 + endTime.Minute()
+					minAct := cfg.DispatcherActivityMax[0]
+					maxAct := cfg.DispatcherActivityMax[1]
+					if endMin <= startMin || maxAct < minAct {
+						return
+					}
+
+					count := rand.Intn(maxAct-minAct+1) + minAct
+
+					currentDay := start.AddDate(0, 0, offset)
+					windowStart := time.Date(currentDay.Year(), currentDay.Month(), currentDay.Day(), startTime.Hour(), startTime.Minute(), 0, 0, time.Local)
+					duration := time.Duration(endMin-startMin) * time.Minute
+					interval := duration / time.Duration(count)
+
+					for i := 0; i < count; i++ {
+						select {
+						case <-ctx.Done():
+							return
+						default:
+						}
+
+						t := windowStart.Add(interval * time.Duration(i))
+						if sleep := time.Until(t); sleep > 0 {
+							select {
+							case <-time.After(sleep):
+							case <-ctx.Done():
+								return
+							}
+						}
+						payload, _ := json.Marshal(act.RequestBody)
+						req, err := http.NewRequestWithContext(ctx, "POST", act.URL, bytes.NewBuffer(payload))
+						if err != nil {
+							continue
+						}
+						req.Header.Set("Content-Type", "application/json")
+						req.Header.Set("Authorization", "Bearer "+bearerToken)
+						http.DefaultClient.Do(req)
+					}
+				}(act, cfg, day)
+			case strings.Contains(act.URL, "unsubscribe"):
+				// Обработка отписки аккаунтов в заданное время
+				if unsubscribeCfg.DispatcherStart == "" {
+					continue
+				}
+
+				startTime, err := time.Parse("15:04", unsubscribeCfg.DispatcherStart)
+				if err != nil {
+					continue
+				}
+
+				wg.Add(1)
+				go func(act ActivityRequest, startTime time.Time, offset int) {
+					defer wg.Done()
+
+					// Вычисляем момент запуска с учётом временной зоны Москвы
+					currentDay := start.AddDate(0, 0, offset).In(loc)
+					target := time.Date(currentDay.Year(), currentDay.Month(), currentDay.Day(), startTime.Hour(), startTime.Minute(), 0, 0, loc)
+
+					if sleep := target.Sub(time.Now().In(loc)); sleep > 0 {
 						select {
 						case <-time.After(sleep):
 						case <-ctx.Done():
 							return
 						}
 					}
+
 					payload, _ := json.Marshal(act.RequestBody)
 					req, err := http.NewRequestWithContext(ctx, "POST", act.URL, bytes.NewBuffer(payload))
 					if err != nil {
-						continue
+						return
 					}
 					req.Header.Set("Content-Type", "application/json")
 					req.Header.Set("Authorization", "Bearer "+bearerToken)
 					http.DefaultClient.Do(req)
-				}
-			}(act, cfg, day)
+				}(act, startTime, day)
+			default:
+				continue
+			}
 		}
 
 		wg.Wait()

--- a/pkg/telegram/module/unsubscribe.go
+++ b/pkg/telegram/module/unsubscribe.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log"
 	"math/rand"
+	"net/url"
+	"strings"
 	"time"
 
 	"atg_go/models"
@@ -15,13 +17,28 @@ import (
 // ModF_UnsubscribeAll отключает указанное количество каналов и групп у всех аккаунтов.
 func ModF_UnsubscribeAll(db *storage.DB, delay [2]int, limit int) error {
 	rand.Seed(time.Now().UnixNano())
+
+	// Получаем ссылки из заказов один раз, чтобы не обращаться к БД при каждой отписке
+	orderLinks, err := db.GetOrdersDefaultURLs()
+	if err != nil {
+		return err
+	}
+
+	// Преобразуем ссылки в множество имён каналов
+	skipChannels := make(map[string]struct{})
+	for _, l := range orderLinks {
+		if name, ok := channelUsernameFromLink(l); ok {
+			skipChannels[strings.ToLower(name)] = struct{}{}
+		}
+	}
+
 	accounts, err := db.GetAuthorizedAccounts()
 	if err != nil {
 		return err
 	}
 	for _, acc := range accounts {
 		log.Printf("[UNSUBSCRIBE] аккаунт %d: начало обработки", acc.ID)
-		if err := unsubscribeAccount(db, &acc, delay, limit); err != nil {
+		if err := unsubscribeAccount(db, &acc, delay, limit, skipChannels); err != nil {
 			log.Printf("[UNSUBSCRIBE] аккаунт %d: %v", acc.ID, err)
 		} else {
 			log.Printf("[UNSUBSCRIBE] аккаунт %d: завершено", acc.ID)
@@ -31,7 +48,7 @@ func ModF_UnsubscribeAll(db *storage.DB, delay [2]int, limit int) error {
 }
 
 // unsubscribeAccount выходит из указанного количества каналов и групп для одного аккаунта.
-func unsubscribeAccount(db *storage.DB, acc *models.Account, delay [2]int, limit int) error {
+func unsubscribeAccount(db *storage.DB, acc *models.Account, delay [2]int, limit int, skip map[string]struct{}) error {
 	client, err := Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID)
 	if err != nil {
 		return err
@@ -50,6 +67,19 @@ func unsubscribeAccount(db *storage.DB, acc *models.Account, delay [2]int, limit
 		if !ok {
 			return nil
 		}
+
+		// Собираем ID обсуждений для каналов, отписка от которых запрещена
+		bannedChats := make(map[int64]struct{})
+		for _, ch := range dialogs.GetChats() {
+			if c, ok := ch.(*tg.Channel); ok {
+				if _, banned := skip[strings.ToLower(c.Username)]; banned {
+					if c.LinkedChatID != 0 {
+						bannedChats[c.LinkedChatID] = struct{}{}
+					}
+				}
+			}
+		}
+
 		count := 0
 		for _, raw := range dialogs.GetDialogs() {
 			if count >= limit {
@@ -62,6 +92,9 @@ func unsubscribeAccount(db *storage.DB, acc *models.Account, delay [2]int, limit
 			switch peer := d.Peer.(type) {
 			case *tg.PeerChannel:
 				if ch := findChannel(dialogs.GetChats(), peer.ChannelID); ch != nil {
+					if _, banned := skip[strings.ToLower(ch.Username)]; banned {
+						continue
+					}
 					time.Sleep(randomDelay(delay))
 					if _, err := api.ChannelsLeaveChannel(ctx, &tg.InputChannel{ChannelID: ch.ID, AccessHash: ch.AccessHash}); err != nil {
 						log.Printf("[UNSUBSCRIBE] аккаунт %d не покинул канал %d: %v", acc.ID, ch.ID, err)
@@ -71,6 +104,9 @@ func unsubscribeAccount(db *storage.DB, acc *models.Account, delay [2]int, limit
 					}
 				}
 			case *tg.PeerChat:
+				if _, banned := bannedChats[peer.ChatID]; banned {
+					continue
+				}
 				time.Sleep(randomDelay(delay))
 				if _, err := api.MessagesDeleteChatUser(ctx, &tg.MessagesDeleteChatUserRequest{ChatID: peer.ChatID, UserID: &tg.InputUserSelf{}}); err != nil {
 					log.Printf("[UNSUBSCRIBE] аккаунт %d не покинул группу %d: %v", acc.ID, peer.ChatID, err)
@@ -100,6 +136,26 @@ func channelAddress(ch *tg.Channel) string {
 		return "https://t.me/" + ch.Username
 	}
 	return "адрес недоступен"
+}
+
+// channelUsernameFromLink извлекает имя канала из URL, если это корректная ссылка на Telegram-канал
+func channelUsernameFromLink(link string) (string, bool) {
+	if !strings.HasPrefix(link, "http://") && !strings.HasPrefix(link, "https://") {
+		link = "https://" + link
+	}
+	u, err := url.Parse(link)
+	if err != nil {
+		return "", false
+	}
+	host := strings.ToLower(u.Host)
+	if host != "t.me" && host != "telegram.me" {
+		return "", false
+	}
+	name := strings.Trim(u.Path, "/")
+	if name == "" || strings.Contains(name, "/") || strings.HasPrefix(name, "+") || strings.HasPrefix(name, "joinchat") || strings.HasPrefix(name, "c/") {
+		return "", false
+	}
+	return name, true
 }
 
 // randomDelay возвращает случайную задержку в заданном диапазоне.


### PR DESCRIPTION
## Summary
- добавлено поле `url_default` в таблицу заказов и модель `Order`
- реализован метод получения ссылок заказов для исключения отписок
- обновлена логика массовой отписки с учётом каналов из `url_default` и связанных обсуждений

## Testing
- `go list ./...`
- `go test ./...` *(прервано: длительное выполнение)*

------
https://chatgpt.com/codex/tasks/task_e_68a1040978bc8327aea3a3759c6669bf