### PR TITLE
Обновление SQL миграций до актуального синтаксиса

### DIFF
--- a/migrations/orders.sql
+++ b/migrations/orders.sql
@@ -1,12 +1,12 @@
 -- Таблица заказов на размещение ссылок
 CREATE TABLE IF NOT EXISTS orders (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- современный автоинкремент
     name TEXT NOT NULL,
     url_description TEXT NOT NULL, -- ссылка для описания аккаунта
     url_default TEXT NOT NULL, -- ссылка по умолчанию
     accounts_number_theory INTEGER NOT NULL,
     accounts_number_fact INTEGER NOT NULL DEFAULT 0,
-    date_time TIMESTAMP NOT NULL DEFAULT NOW()
+    date_time TIMESTAMPTZ NOT NULL DEFAULT NOW() -- сохраняем время с учётом часового пояса
 );
 
 -- Добавление поля order_id в таблицу accounts
@@ -58,3 +58,4 @@ ALTER TABLE accounts
 ALTER TABLE accounts
     ADD CONSTRAINT accounts_order_id_fkey
         FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE SET NULL; -- При удалении заказа поле обнуляется
+

--- a/migrations/proxy.sql
+++ b/migrations/proxy.sql
@@ -1,6 +1,6 @@
 -- Таблица прокси-серверов
 CREATE TABLE IF NOT EXISTS proxy (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- современный автоинкремент
     ip TEXT NOT NULL,
     port INTEGER NOT NULL,
     login TEXT,

--- a/migrations/statistics.sql
+++ b/migrations/statistics.sql
@@ -3,7 +3,7 @@
 
 -- Создание таблицы со статистикой
 CREATE TABLE IF NOT EXISTS statistics (
-    id SERIAL PRIMARY KEY,                    -- Уникальный идентификатор записи
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- современный автоинкремент
     stat_date DATE NOT NULL UNIQUE,          -- Дата, за которую рассчитана статистика (МСК)
     comment_mean DOUBLE PRECISION NOT NULL,  -- Среднее число комментариев на аккаунт
     reaction_mean DOUBLE PRECISION NOT NULL, -- Среднее число реакций на аккаунт
@@ -70,3 +70,4 @@ BEGIN
     WHERE id = p_account_id;
 END;
 $$ LANGUAGE plpgsql;
+

--- a/migrations/tables.sql
+++ b/migrations/tables.sql
@@ -1,36 +1,36 @@
 -- Основная таблица аккаунтов Telegram
 CREATE TABLE IF NOT EXISTS accounts (
-    id SERIAL PRIMARY KEY,                           -- Уникальный идентификатор аккаунта
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- современный автоинкремент
     phone TEXT NOT NULL UNIQUE,                      -- Номер телефона в формате +79991112233 (уникальный)
     api_id INTEGER NOT NULL,                         -- API ID из my.telegram.org
     api_hash TEXT NOT NULL,                          -- API Hash из my.telegram.org
     is_authorized BOOLEAN DEFAULT false,             -- Флаг успешной авторизации
     phone_code_hash TEXT,                            -- Хэш кода подтверждения из Telegram
-    floodwait_until TIMESTAMP NULL,                 -- Время окончания флуд-бана (NULL если нет блокировки)
+    floodwait_until TIMESTAMPTZ NULL,                -- Время окончания флуд-бана с учётом часового пояса
     proxy_id INTEGER REFERENCES proxy(id)          -- Привязка к прокси
 );
 
 -- Таблица со списокм каналов в определенной тематике 
 CREATE TABLE IF NOT EXISTS channels (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- современный автоинкремент
     name TEXT NOT NULL,              -- Произвольное название группы каналов
     urls JSONB NOT NULL              -- Массив URL в формате ["https://t.me/channel1", "https://t.me/channel2"]
 );
 
 -- Таблица активности аккаунтов
 CREATE TABLE IF NOT EXISTS activity (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- современный автоинкремент
     id_account INTEGER NOT NULL,
     id_channel VARCHAR(20) NOT NULL, -- ID канала как строка до 20 символов
     id_message VARCHAR(20) NOT NULL, -- ID сообщения (для реакций из обсуждения, для комментариев ID поста)
     activity_type TEXT NOT NULL,
-    date_time TIMESTAMP NOT NULL DEFAULT NOW()
+    date_time TIMESTAMPTZ NOT NULL DEFAULT NOW() -- Время события с учётом часового пояса
 );
 
 -- Таблица для хранения сессий аккаунтов Telegram
 CREATE TABLE IF NOT EXISTS account_session (
-    id SERIAL PRIMARY KEY,
-    date_time TIMESTAMP NOT NULL DEFAULT NOW(),
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- современный автоинкремент
+    date_time TIMESTAMPTZ NOT NULL DEFAULT NOW(), -- Время сохранения сессии с часовым поясом
     account INTEGER NOT NULL UNIQUE REFERENCES accounts(id) ON DELETE CASCADE,
     data_json TEXT NOT NULL
 );


### PR DESCRIPTION
## Summary
- перейти на GENERATED AS IDENTITY вместо SERIAL
- хранить время как TIMESTAMPTZ

## Testing
- `go vet ./...` (зависает в среде)
- `go test ./...` (зависает в среде)


------
https://chatgpt.com/codex/tasks/task_e_68a1aeb2658c83279291da5c3870d221