### PR TITLE
Добавить перечисление пола и связь категорий заказов

### DIFF
--- a/migrations/orders.sql
+++ b/migrations/orders.sql
@@ -2,11 +2,12 @@
 CREATE TABLE IF NOT EXISTS orders (
     id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- современный автоинкремент
     name TEXT NOT NULL,
-    category TEXT NOT NULL, -- Название категории (берём из channels.name)
+    category TEXT REFERENCES channels(name) DEFAULT NULL, -- Название категории из таблицы channels
     url_description TEXT NOT NULL, -- ссылка для описания аккаунта
     url_default TEXT NOT NULL, -- ссылка по умолчанию
     accounts_number_theory INTEGER NOT NULL,
     accounts_number_fact INTEGER NOT NULL DEFAULT 0,
+    gender gender_enum NOT NULL DEFAULT 'neutral', -- Пол для отбора аккаунтов
     date_time TIMESTAMPTZ NOT NULL DEFAULT NOW() -- сохраняем время с учётом часового пояса
 );
 

--- a/migrations/tables.sql
+++ b/migrations/tables.sql
@@ -1,3 +1,6 @@
+-- Тип перечисления для пола аккаунтов
+CREATE TYPE gender_enum AS ENUM ('male', 'female', 'neutral');
+
 -- Основная таблица аккаунтов Telegram
 CREATE TABLE IF NOT EXISTS accounts (
     id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- современный автоинкремент
@@ -5,7 +8,7 @@ CREATE TABLE IF NOT EXISTS accounts (
     api_id INTEGER NOT NULL,                         -- API ID из my.telegram.org
     api_hash TEXT NOT NULL,                          -- API Hash из my.telegram.org
     is_authorized BOOLEAN DEFAULT false,             -- Флаг успешной авторизации
-    gender TEXT NOT NULL DEFAULT 'neutral' CHECK (gender IN ('male', 'female', 'neutral')), -- Пол аккаунта
+    gender gender_enum[] NOT NULL DEFAULT ARRAY['neutral']::gender_enum[] CHECK (array_length(gender,1) > 0), -- Пол(ы) аккаунта
     phone_code_hash TEXT,                            -- Хэш кода подтверждения из Telegram
     floodwait_until TIMESTAMPTZ NULL,                -- Время окончания флуд-бана с учётом часового пояса
     channels_limit_until TIMESTAMPTZ NULL,           -- Время, до которого запрещены новые подписки
@@ -16,7 +19,7 @@ CREATE TABLE IF NOT EXISTS accounts (
 -- Таблица со списокм каналов в определенной тематике 
 CREATE TABLE IF NOT EXISTS channels (
     id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- современный автоинкремент
-    name TEXT NOT NULL,              -- Произвольное название группы каналов
+    name TEXT NOT NULL UNIQUE,        -- Произвольное название группы каналов (уникальное для FK)
     urls JSONB NOT NULL              -- Массив URL в формате ["https://t.me/channel1", "https://t.me/channel2"]
 );
 

--- a/models/account.go
+++ b/models/account.go
@@ -1,14 +1,16 @@
 package models
 
+import "github.com/lib/pq"
+
 type Account struct {
-	ID            int    `json:"id"`
-	Phone         string `json:"phone"`
-	ApiID         int    `json:"api_id"`
-	ApiHash       string `json:"api_hash"`
-	IsAuthorized  bool   `json:"is_authorized"`
-	Gender        string `json:"gender"` // Пол аккаунта: male, female или neutral
-	PhoneCodeHash string `json:"phone_code_hash"`
-	ProxyID       *int   `json:"proxy_id"`
-	OrderID       *int   `json:"order_id"` // ID выполняемого заказа (NULL, если аккаунт свободен)
-	Proxy         *Proxy `json:"proxy"`
+	ID            int            `json:"id"`
+	Phone         string         `json:"phone"`
+	ApiID         int            `json:"api_id"`
+	ApiHash       string         `json:"api_hash"`
+	IsAuthorized  bool           `json:"is_authorized"`
+	Gender        pq.StringArray `json:"gender"` // Пол(ы) аккаунта: допускается несколько значений
+	PhoneCodeHash string         `json:"phone_code_hash"`
+	ProxyID       *int           `json:"proxy_id"`
+	OrderID       *int           `json:"order_id"` // ID выполняемого заказа (NULL, если аккаунт свободен)
+	Proxy         *Proxy         `json:"proxy"`
 }

--- a/models/order.go
+++ b/models/order.go
@@ -15,10 +15,11 @@ import "time"
 type Order struct {
 	ID                   int       `json:"id"`
 	Name                 string    `json:"name"`
-	Category             string    `json:"category"`        // Название категории (из таблицы channels)
+	Category             *string   `json:"category"`        // Категория из таблицы channels (может быть NULL)
 	URLDescription       string    `json:"url_description"` // Текст ссылки для описания
 	URLDefault           string    `json:"url_default"`     // Ссылка по умолчанию
 	AccountsNumberTheory int       `json:"accounts_number_theory"`
 	AccountsNumberFact   int       `json:"accounts_number_fact"`
+	Gender               string    `json:"gender"` // Пол аккаунтов для заказа
 	DateTime             time.Time `json:"date_time"`
 }

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 )
 
 type DB struct {
@@ -62,10 +62,10 @@ func (db *DB) CreateAccount(account models.Account) (*models.Account, error) {
               RETURNING id
        `
 
-	// Если пол не указан или задан неверно, используем значение по умолчанию
+	// Если пол не указан, устанавливаем значение по умолчанию
 	gender := account.Gender
-	if gender != "male" && gender != "female" {
-		gender = "neutral"
+	if len(gender) == 0 {
+		gender = pq.StringArray{"neutral"}
 	}
 
 	err := db.Conn.QueryRow(
@@ -75,7 +75,7 @@ func (db *DB) CreateAccount(account models.Account) (*models.Account, error) {
 		account.ApiHash,
 		account.PhoneCodeHash,
 		account.ProxyID,
-		gender,
+		pq.Array(gender),
 	).Scan(&account.ID)
 
 	if err != nil {
@@ -115,7 +115,7 @@ func (db *DB) GetAccountByID(id int) (*models.Account, error) {
 		&account.ApiHash,
 		&account.PhoneCodeHash,
 		&account.IsAuthorized,
-		&account.Gender,
+		pq.Array(&account.Gender),
 		&account.ProxyID,
 		&account.OrderID,
 		&proxyID,
@@ -192,7 +192,7 @@ func (db *DB) GetLastAccount() (*models.Account, error) {
 		&account.ApiHash,
 		&account.PhoneCodeHash,
 		&account.IsAuthorized,
-		&account.Gender,
+		pq.Array(&account.Gender),
 		&account.ProxyID,
 		&account.OrderID,
 		&proxyID,
@@ -282,7 +282,7 @@ func (db *DB) GetAccountByPhone(phone string) (*models.Account, error) {
 		&account.ApiHash,
 		&account.PhoneCodeHash,
 		&account.IsAuthorized,
-		&account.Gender,
+		pq.Array(&account.Gender),
 		&account.ProxyID,
 		&account.OrderID,
 		&proxyID,
@@ -384,7 +384,7 @@ func (db *DB) GetAuthorizedAccounts() ([]models.Account, error) {
 			&account.ApiHash,
 			&account.PhoneCodeHash,
 			&account.IsAuthorized,
-			&account.Gender,
+			pq.Array(&account.Gender),
 			&accountProxyID,
 			&accountOrderID,
 			&proxyID,


### PR DESCRIPTION
## Summary
- добавить тип `gender_enum` и использовать массив полов в `accounts`
- связать `orders.category` с `channels.name` и добавить поле `orders.gender`
- обновить модели и хранилища для работы с новыми полями

## Testing
- ⚠️ `go test ./...` (команда зависла, выполнение прервано)


------
https://chatgpt.com/codex/tasks/task_e_68a46fcf71d483279902b7833a2b17b2