### PR TITLE
Allow multiple genders for orders

### DIFF
--- a/migrations/orders.sql
+++ b/migrations/orders.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS orders (
     url_default TEXT NOT NULL, -- ссылка по умолчанию
     accounts_number_theory INTEGER NOT NULL,
     accounts_number_fact INTEGER NOT NULL DEFAULT 0,
-    gender gender_enum NOT NULL DEFAULT 'neutral', -- Пол для отбора аккаунтов
+    gender gender_enum[] NOT NULL DEFAULT ARRAY['neutral']::gender_enum[] CHECK (array_length(gender,1) > 0), -- Пол(ы) для отбора аккаунтов
     date_time TIMESTAMPTZ NOT NULL DEFAULT NOW() -- сохраняем время с учётом часового пояса
 );
 

--- a/models/gender.go
+++ b/models/gender.go
@@ -1,0 +1,36 @@
+package models
+
+import "github.com/lib/pq"
+
+// AllowedGenders содержит список допустимых значений пола
+var AllowedGenders = []string{"male", "female", "neutral"}
+
+// DefaultGender используется, если пол не указан или указан неверно
+const DefaultGender = "neutral"
+
+// IsValidGender проверяет, что переданное значение входит в список допустимых
+func IsValidGender(g string) bool {
+	for _, allowed := range AllowedGenders {
+		if g == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterGenders отбрасывает недопустимые значения и гарантирует минимум одно допустимое значение
+// Это защищает от рассинхронизации данных при изменении списка AllowedGenders
+func FilterGenders(genders pq.StringArray) pq.StringArray {
+	var filtered pq.StringArray
+	for _, g := range genders {
+		if IsValidGender(g) {
+			filtered = append(filtered, g)
+		}
+	}
+	if len(filtered) == 0 {
+		// Если все значения оказались недопустимыми, используем значение по умолчанию,
+		// чтобы заказ или аккаунт всегда имел хотя бы один пол
+		filtered = pq.StringArray{DefaultGender}
+	}
+	return filtered
+}

--- a/models/order.go
+++ b/models/order.go
@@ -1,6 +1,10 @@
 package models
 
-import "time"
+import (
+	"time"
+
+	"github.com/lib/pq"
+)
 
 // Order описывает заказ на размещение ссылки в описании аккаунтов
 // name - произвольное название заказа
@@ -13,13 +17,13 @@ import "time"
 // Комментарии в коде на русском языке по требованию пользователя
 
 type Order struct {
-	ID                   int       `json:"id"`
-	Name                 string    `json:"name"`
-	Category             *string   `json:"category"`        // Категория из таблицы channels (может быть NULL)
-	URLDescription       string    `json:"url_description"` // Текст ссылки для описания
-	URLDefault           string    `json:"url_default"`     // Ссылка по умолчанию
-	AccountsNumberTheory int       `json:"accounts_number_theory"`
-	AccountsNumberFact   int       `json:"accounts_number_fact"`
-	Gender               string    `json:"gender"` // Пол аккаунтов для заказа
-	DateTime             time.Time `json:"date_time"`
+	ID                   int            `json:"id"`
+	Name                 string         `json:"name"`
+	Category             *string        `json:"category"`        // Категория из таблицы channels (может быть NULL)
+	URLDescription       string         `json:"url_description"` // Текст ссылки для описания
+	URLDefault           string         `json:"url_default"`     // Ссылка по умолчанию
+	AccountsNumberTheory int            `json:"accounts_number_theory"`
+	AccountsNumberFact   int            `json:"accounts_number_fact"`
+	Gender               pq.StringArray `json:"gender"` // Пол(ы) аккаунтов для заказа
+	DateTime             time.Time      `json:"date_time"`
 }

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -62,11 +62,8 @@ func (db *DB) CreateAccount(account models.Account) (*models.Account, error) {
               RETURNING id
        `
 
-	// Если пол не указан, устанавливаем значение по умолчанию
-	gender := account.Gender
-	if len(gender) == 0 {
-		gender = pq.StringArray{"neutral"}
-	}
+	// Фильтруем список полов через общую функцию, чтобы избежать дублирования логики
+	gender := models.FilterGenders(account.Gender)
 
 	err := db.Conn.QueryRow(
 		query,


### PR DESCRIPTION
## Summary
- allow orders to store multiple genders just like accounts
- centralize gender validation with shared FilterGenders helper
- adapt migrations and storage logic to handle gender arrays

## Testing
- `go list ./...`
- `go test ./...` *(interrupted: command hung)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc0b8bf0832781d640cef696a469