### PR TITLE
Разрешать активности только аккаунтам с заказом

### DIFF
--- a/internal/comments/handler.go
+++ b/internal/comments/handler.go
@@ -1,6 +1,7 @@
 package comments
 
 import (
+	"atg_go/models"
 	"atg_go/pkg/storage"
 	"atg_go/pkg/telegram"
 	"database/sql"
@@ -46,9 +47,21 @@ func (h *CommentHandler) SendComment(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get accounts"})
 		return
 	}
+
+	// Оставляем только аккаунты, которые привязаны к заказу.
+	// Это важно, поскольку активность разрешена исключительно для аккаунтов,
+	// выполняющих заказ, чтобы избежать действий «свободных» аккаунтов.
+	var orderedAccounts []models.Account
+	for _, acc := range accounts {
+		if acc.OrderID != nil {
+			orderedAccounts = append(orderedAccounts, acc)
+		}
+	}
+	accounts = orderedAccounts
+
 	if len(accounts) == 0 {
-		log.Printf("[HANDLER WARN] No authorized accounts found")
-		c.JSON(http.StatusNotFound, gin.H{"error": "No authorized accounts available"})
+		log.Printf("[HANDLER WARN] No authorized accounts with order found")
+		c.JSON(http.StatusNotFound, gin.H{"error": "No authorized ordered accounts available"})
 		return
 	}
 

--- a/internal/reaction/handler.go
+++ b/internal/reaction/handler.go
@@ -1,6 +1,7 @@
 package reaction
 
 import (
+	"atg_go/models"
 	"atg_go/pkg/storage"
 	"atg_go/pkg/telegram"
 	"database/sql"
@@ -48,9 +49,20 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get accounts"})
 		return
 	}
+
+	// Фильтруем аккаунты, оставляя только те, что закреплены за заказом.
+	// Так мы предотвращаем участие свободных аккаунтов в активности.
+	var orderedAccounts []models.Account
+	for _, acc := range accounts {
+		if acc.OrderID != nil {
+			orderedAccounts = append(orderedAccounts, acc)
+		}
+	}
+	accounts = orderedAccounts
+
 	if len(accounts) == 0 {
-		log.Printf("[HANDLER WARN] Нет авторизованных аккаунтов")
-		c.JSON(http.StatusNotFound, gin.H{"error": "No authorized accounts available"})
+		log.Printf("[HANDLER WARN] Нет авторизованных аккаунтов с заказом")
+		c.JSON(http.StatusNotFound, gin.H{"error": "No authorized ordered accounts available"})
 		return
 	}
 


### PR DESCRIPTION
## Summary
- фильтрация аккаунтов в обработчиках комментариев и реакций: активность выполняют только аккаунты с `order_id`

## Testing
- `go test ./...` *(зависло, не получен вывод)*
- `go vet ./...` *(зависло, не получен вывод)*

------
https://chatgpt.com/codex/tasks/task_e_68a4eb0e20a88327b5367f8b00dca522