### PR TITLE
Фильтрация каналов по категориям заказа

### DIFF
--- a/internal/comments/handler.go
+++ b/internal/comments/handler.go
@@ -106,7 +106,8 @@ func (h *CommentHandler) SendComment(c *gin.Context) {
 		}
 
 		// --- Выбор канала для каждого аккаунта ---
-		channelURL, err := h.CommentDB.GetRandomChannel()
+		// Используем категории заказа, чтобы аккаунт не выходил за рамки своей задачи.
+		channelURL, err := h.CommentDB.GetRandomChannel(*account.OrderID)
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Printf("[HANDLER ERROR] No channels available: %v", err)
 			c.JSON(http.StatusNotFound, gin.H{"error": "No channels available"})

--- a/internal/reaction/handler.go
+++ b/internal/reaction/handler.go
@@ -94,7 +94,8 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 		}
 
 		// Выбор случайного канала
-		channelURL, err := h.CommentDB.GetRandomChannel()
+		// Сужаем выборку каналов до категорий заказа, чтобы реакция попадала в нужную аудиторию.
+		channelURL, err := h.CommentDB.GetRandomChannel(*account.OrderID)
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Printf("[HANDLER ERROR] Нет доступных каналов: %v", err)
 			c.JSON(http.StatusNotFound, gin.H{"error": "No channels available"})


### PR DESCRIPTION
## Summary
- ограничил выбор каналов категориями выполняемого заказа
- удалил неиспользуемую логику выбора канала

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a4f13de39483278997099802b396d1