### PR TITLE
feat: support multiple order categories

### DIFF
--- a/migrations/orders_category_array.sql
+++ b/migrations/orders_category_array.sql
@@ -1,0 +1,6 @@
+-- Перевод поля category в массив, чтобы один заказ мог относиться к нескольким категориям
+ALTER TABLE orders
+    DROP CONSTRAINT IF EXISTS orders_category_fkey,
+    ALTER COLUMN category TYPE TEXT[] USING ARRAY[category], -- существующие значения превращаем в массив из одного элемента
+    ALTER COLUMN category SET DEFAULT NULL; -- избегаем значения по умолчанию, чтобы отсутствие категорий обозначалось NULL
+

--- a/models/order.go
+++ b/models/order.go
@@ -19,7 +19,7 @@ import (
 type Order struct {
 	ID                   int            `json:"id"`
 	Name                 string         `json:"name"`
-	Category             *string        `json:"category"`        // Категория из таблицы channels (может быть NULL)
+	Category             pq.StringArray `json:"category"`        // Перечень категорий из channels; может быть пустым
 	URLDescription       string         `json:"url_description"` // Текст ссылки для описания
 	URLDefault           string         `json:"url_default"`     // Ссылка по умолчанию
 	AccountsNumberTheory int            `json:"accounts_number_theory"`


### PR DESCRIPTION
## Summary
- allow orders to store several categories
- validate category names before order creation
- keep random channel choice within matching categories
- move category column change to separate migration

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a5a45b0614832799f994195faf5829