### PR TITLE
Лог активных сессий случайного аккаунта с номером телефона

### DIFF
--- a/pkg/telegram/module/active_sessions_disconnect/info.go
+++ b/pkg/telegram/module/active_sessions_disconnect/info.go
@@ -3,6 +3,8 @@ package active_sessions_disconnect
 import (
 	"context"
 	"log"
+	"math/rand"
+	"time"
 
 	"atg_go/pkg/storage"
 	"atg_go/pkg/telegram/module"
@@ -10,38 +12,44 @@ import (
 	"github.com/gotd/td/tg"
 )
 
-// LogAuthorizations выводит в журнал данные всех активных сессий
-// для каждого авторизованного аккаунта. Это помогает оперативно
-// проверить, какие устройства используют аккаунты в данный момент.
+// LogAuthorizations выводит в журнал данные активных сессий
+// случайного авторизованного аккаунта. Это позволяет не захламлять
+// логи данными всех аккаунтов одновременно и сразу видеть телефон
+// выбранного аккаунта.
 func LogAuthorizations(db *storage.DB) error {
 	accounts, err := db.GetAuthorizedAccounts()
 	if err != nil {
 		return err
 	}
+	if len(accounts) == 0 {
+		return nil
+	}
 
-	for _, acc := range accounts {
-		// Инициализируем клиента Telegram для аккаунта
-		client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID)
+	// Выбираем один аккаунт случайным образом, чтобы контролировать объём логов
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	acc := accounts[rnd.Intn(len(accounts))]
+
+	// Инициализируем клиента Telegram для выбранного аккаунта
+	client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID)
+	if err != nil {
+		log.Printf("[ACTIVE SESSIONS] аккаунт %d (%s): ошибка инициализации: %v", acc.ID, acc.Phone, err)
+		return nil
+	}
+
+	ctx := context.Background()
+	if err := client.Run(ctx, func(ctx context.Context) error {
+		api := tg.NewClient(client)
+		auths, err := api.AccountGetAuthorizations(ctx)
 		if err != nil {
-			log.Printf("[ACTIVE SESSIONS] аккаунт %d: ошибка инициализации: %v", acc.ID, err)
-			continue
+			return err
 		}
-
-		ctx := context.Background()
-		if err := client.Run(ctx, func(ctx context.Context) error {
-			api := tg.NewClient(client)
-			auths, err := api.AccountGetAuthorizations(ctx)
-			if err != nil {
-				return err
-			}
-			// Логируем каждую сессию отдельно, чтобы сохранить максимум деталей
-			for _, a := range auths.Authorizations {
-				log.Printf("[ACTIVE SESSIONS] аккаунт %d: %+v", acc.ID, a)
-			}
-			return nil
-		}); err != nil {
-			log.Printf("[ACTIVE SESSIONS] аккаунт %d: ошибка получения сессий: %v", acc.ID, err)
+		// Логируем каждую сессию отдельно, добавляя телефон для наглядности
+		for _, a := range auths.Authorizations {
+			log.Printf("[ACTIVE SESSIONS] аккаунт %d (%s): %+v", acc.ID, acc.Phone, a)
 		}
+		return nil
+	}); err != nil {
+		log.Printf("[ACTIVE SESSIONS] аккаунт %d (%s): ошибка получения сессий: %v", acc.ID, acc.Phone, err)
 	}
 	return nil
 }


### PR DESCRIPTION
### Изменения
- выводим активные сессии только одного случайного авторизованного аккаунта и логируем его номер телефона

### Тесты
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a6dcde929c83278caba499633611d9