### PR TITLE
feat: disconnect suspicious sessions

### DIFF
--- a/internal/module/active_sessions_disconnect/handler.go
+++ b/internal/module/active_sessions_disconnect/handler.go
@@ -1,6 +1,7 @@
 package active_sessions_disconnect
 
 import (
+	"log"
 	"net/http"
 
 	"atg_go/pkg/storage"
@@ -28,4 +29,21 @@ func (h *Handler) Info(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "logged"})
+}
+
+// Disconnect отключает подозрительные сессии на всех авторизованных аккаунтах.
+// Возвращает информацию об отключённых устройствах или сообщение об их отсутствии.
+func (h *Handler) Disconnect(c *gin.Context) {
+	res, err := telegrammodule.DisconnectSuspiciousSessions(h.DB)
+	if err != nil {
+		// Логируем ошибку, чтобы понять, где произошёл сбой
+		log.Printf("[ACTIVE SESSIONS DISCONNECT] ошибка выполнения: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if len(res) == 0 {
+		c.JSON(http.StatusOK, gin.H{"Ответ": "Аккаунты не пытались увести"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"Ответ": res})
 }

--- a/internal/module/active_sessions_disconnect/routes.go
+++ b/internal/module/active_sessions_disconnect/routes.go
@@ -10,5 +10,6 @@ import (
 func SetupRoutes(r *gin.RouterGroup, db *storage.DB) {
 	handler := NewHandler(db)
 	// Используем POST, чтобы соответствовать соглашению модульных маршрутов.
+	r.POST("", handler.Disconnect)
 	r.POST("/info", handler.Info)
 }

--- a/pkg/telegram/module/active_sessions_disconnect/disconnect.go
+++ b/pkg/telegram/module/active_sessions_disconnect/disconnect.go
@@ -1,0 +1,61 @@
+package active_sessions_disconnect
+
+import (
+	"context"
+	"log"
+
+	"atg_go/pkg/storage"
+	"atg_go/pkg/telegram/module"
+
+	"github.com/gotd/td/tg"
+)
+
+// DisconnectSuspiciousSessions отключает неактивные сессии для всех авторизованных аккаунтов.
+// Сессии отключаются, если они не текущие и их устройство не совпадает с разрешённым.
+func DisconnectSuspiciousSessions(db *storage.DB) (map[string][]string, error) {
+	accounts, err := db.GetAuthorizedAccounts()
+	if err != nil {
+		// Логируем ошибку, чтобы быстрее найти проблемы с БД
+		log.Printf("[ACTIVE SESSIONS DISCONNECT] ошибка получения аккаунтов: %v", err)
+		return nil, err
+	}
+
+	result := make(map[string][]string)
+
+	for _, acc := range accounts {
+		client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID)
+		if err != nil {
+			// Не прерываем работу из-за одного аккаунта, чтобы обработать остальные
+			log.Printf("[ACTIVE SESSIONS DISCONNECT] аккаунт %s: ошибка инициализации: %v", acc.Phone, err)
+			continue
+		}
+
+		ctx := context.Background()
+		if err := client.Run(ctx, func(ctx context.Context) error {
+			api := tg.NewClient(client)
+			auths, err := api.AccountGetAuthorizations(ctx)
+			if err != nil {
+				return err
+			}
+			for _, a := range auths.Authorizations {
+				if a.Current {
+					continue
+				}
+				if a.DeviceModel == "HP Laptop 14s-dq2xxx" {
+					continue
+				}
+				if _, err := api.AccountResetAuthorization(ctx, a.Hash); err != nil {
+					log.Printf("[ACTIVE SESSIONS DISCONNECT] аккаунт %s: не удалось отключить %s: %v", acc.Phone, a.DeviceModel, err)
+					continue
+				}
+				log.Printf("[ACTIVE SESSIONS DISCONNECT] аккаунт %s: отключено устройство %s", acc.Phone, a.DeviceModel)
+				result[acc.Phone] = append(result[acc.Phone], a.DeviceModel)
+			}
+			return nil
+		}); err != nil {
+			log.Printf("[ACTIVE SESSIONS DISCONNECT] аккаунт %s: ошибка обработки: %v", acc.Phone, err)
+		}
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
## Summary
- add endpoint to terminate suspicious sessions across all accounts
- expose POST /module/active_sessions_disconnect route

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a78726c8b88327ad93d024e01fa32b