### PR TITLE
feat: schedule active sessions disconnect

### DIFF
--- a/internal/module/handler.go
+++ b/internal/module/handler.go
@@ -28,14 +28,15 @@ func NewHandler(db *storage.DB) *Handler {
 }
 
 // DispatcherActivity запускает модульную активность диспатчера.
-// Ожидает JSON со списком activity_request, где у каждого запроса есть url и request_body.
+// Помимо activity_request ожидает параметры запуска для разных типов действий.
 func (h *Handler) DispatcherActivity(c *gin.Context) {
 	var req struct {
-		DaysNumber                  int                                `json:"days_number" binding:"required"`
-		ActivityRequest             []telegrammodule.ActivityRequest   `json:"activity_request" binding:"required"`
-		ActivityComment             telegrammodule.ActivitySettings    `json:"activity_comment" binding:"required"`
-		ActivityReaction            telegrammodule.ActivitySettings    `json:"activity_reaction" binding:"required"`
-		ActivityAccountsUnsubscribe telegrammodule.UnsubscribeSettings `json:"activity_accounts_unsubscribe" binding:"required"`
+		DaysNumber                       int                                             `json:"days_number" binding:"required"`
+		ActivityRequest                  []telegrammodule.ActivityRequest                `json:"activity_request" binding:"required"`
+		ActivityComment                  telegrammodule.ActivitySettings                 `json:"activity_comment" binding:"required"`
+		ActivityReaction                 telegrammodule.ActivitySettings                 `json:"activity_reaction" binding:"required"`
+		ActivityAccountsUnsubscribe      telegrammodule.UnsubscribeSettings              `json:"activity_accounts_unsubscribe" binding:"required"`
+		ActivityActiveSessionsDisconnect telegrammodule.ActiveSessionsDisconnectSettings `json:"activity_active_sessions_disconnect" binding:"required"`
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -58,7 +59,7 @@ func (h *Handler) DispatcherActivity(c *gin.Context) {
 			delete(h.tasks, taskID)
 			h.mu.Unlock()
 		}()
-		telegrammodule.ModF_DispatcherActivity(ctx, req.DaysNumber, req.ActivityRequest, req.ActivityComment, req.ActivityReaction, req.ActivityAccountsUnsubscribe)
+		telegrammodule.ModF_DispatcherActivity(ctx, req.DaysNumber, req.ActivityRequest, req.ActivityComment, req.ActivityReaction, req.ActivityAccountsUnsubscribe, req.ActivityActiveSessionsDisconnect)
 	}(id)
 
 	c.JSON(http.StatusOK, gin.H{"status": "запущено", "task_id": id})


### PR DESCRIPTION
## Summary
- accept `activity_active_sessions_disconnect` in dispatcher_activity
- run active_sessions_disconnect at configured start time

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a796e160408327992baeb60fb9995a