### PR TITLE
Добавлен модуль проверки авторизации аккаунтов

### DIFF
--- a/internal/module/account_auth_check/handler.go
+++ b/internal/module/account_auth_check/handler.go
@@ -1,0 +1,45 @@
+package account_auth_check
+
+import (
+	"log"
+	"net/http"
+
+	"atg_go/pkg/storage"
+	authcheck "atg_go/pkg/telegram/module/account_auth_check"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler обрабатывает запросы проверки авторизации аккаунтов.
+type Handler struct {
+	DB *storage.DB
+}
+
+// NewHandler создаёт новый экземпляр обработчика.
+func NewHandler(db *storage.DB) *Handler {
+	return &Handler{DB: db}
+}
+
+// Check проходит по всем аккаунтам и фиксирует потерю авторизации.
+// Возвращает список телефонов, для которых сессия отсутствует.
+func (h *Handler) Check(c *gin.Context) {
+	accounts, err := h.DB.GetAuthorizedAccounts()
+	if err != nil {
+		log.Printf("[ACCOUNT AUTH CHECK] ошибка получения аккаунтов: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	var unauth []string
+	for _, acc := range accounts {
+		if !authcheck.Check(h.DB, acc) {
+			unauth = append(unauth, acc.Phone)
+		}
+	}
+
+	if len(unauth) == 0 {
+		c.JSON(http.StatusOK, gin.H{"status": "все аккаунты авторизованы"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"неавторизованы": unauth})
+}

--- a/internal/module/account_auth_check/routes.go
+++ b/internal/module/account_auth_check/routes.go
@@ -1,0 +1,14 @@
+package account_auth_check
+
+import (
+	"atg_go/pkg/storage"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SetupRoutes регистрирует маршрут проверки авторизации аккаунтов.
+func SetupRoutes(r *gin.RouterGroup, db *storage.DB) {
+	handler := NewHandler(db)
+	// Используем POST, чтобы не кэшировать результат и соответствовать стилю API.
+	r.POST("", handler.Check)
+}

--- a/internal/module/routes.go
+++ b/internal/module/routes.go
@@ -1,6 +1,7 @@
 package module
 
 import (
+	authcheck "atg_go/internal/module/account_auth_check"
 	activesessions "atg_go/internal/module/active_sessions_disconnect"
 	"atg_go/pkg/storage"
 
@@ -14,5 +15,6 @@ func SetupRoutes(r *gin.RouterGroup, db *storage.DB) {
 	r.POST("/dispatcher_activity/cancel_all", handler.CancelAllDispatcherActivity)
 	r.POST("/unsubscribe", handler.Unsubscribe)
 	r.POST("/order/link_updat", handler.OrderLinkUpdate)
+	authcheck.SetupRoutes(r.Group("/account_auth_check"), db)
 	activesessions.SetupRoutes(r.Group("/active_sessions_disconnect"), db)
 }

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -243,6 +243,16 @@ func (db *DB) MarkAccountAsAuthorized(accountID int) error {
 	return err
 }
 
+// MarkAccountAsUnauthorized сбрасывает флаг авторизации,
+// чтобы в БД отражалось фактическое отсутствие рабочей сессии.
+func (db *DB) MarkAccountAsUnauthorized(accountID int) error {
+	_, err := db.Conn.Exec(
+		"UPDATE accounts SET is_authorized = false WHERE id = $1",
+		accountID,
+	)
+	return err
+}
+
 // Обновляет phone_code_hash для указанного аккаунта
 func (db *DB) UpdatePhoneCodeHash(accountID int, hash string) error {
 	_, err := db.Conn.Exec(

--- a/pkg/telegram/module/account_auth_check/check.go
+++ b/pkg/telegram/module/account_auth_check/check.go
@@ -1,0 +1,58 @@
+package account_auth_check
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"atg_go/models"
+	"atg_go/pkg/storage"
+	"atg_go/pkg/telegram/module"
+
+	"github.com/gotd/td/session"
+	"github.com/gotd/td/tg"
+)
+
+// Check проверяет, сохранилась ли авторизация аккаунта.
+// При отсутствии сессии или ошибке Telegram фиксируем событие в Sos
+// и сбрасываем флаг авторизации.
+func Check(db *storage.DB, acc models.Account) bool {
+	client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID)
+	if err != nil {
+		// Инициализация клиента без сессии невозможна, считаем аккаунт неавторизованным.
+		log.Printf("[ACCOUNT AUTH CHECK] аккаунт %s: ошибка инициализации: %v", acc.Phone, err)
+		markUnauthorized(db, acc)
+		return false
+	}
+
+	ctx := context.Background()
+	err = client.Run(ctx, func(ctx context.Context) error {
+		api := tg.NewClient(client)
+		_, err := api.UsersGetFullUser(ctx, &tg.InputUserSelf{})
+		return err
+	})
+	if err != nil {
+		// Любая ошибка при запросе означает, что сессия недействительна или отсутствует.
+		if err == session.ErrNotFound {
+			log.Printf("[ACCOUNT AUTH CHECK] аккаунт %s: сессия не найдена", acc.Phone)
+		} else {
+			log.Printf("[ACCOUNT AUTH CHECK] аккаунт %s: ошибка запроса: %v", acc.Phone, err)
+		}
+		markUnauthorized(db, acc)
+		return false
+	}
+
+	// Авторизация присутствует, дополнительных действий не требуется.
+	return true
+}
+
+// markUnauthorized сбрасывает флаг авторизации и пишет сообщение в Sos.
+func markUnauthorized(db *storage.DB, acc models.Account) {
+	if err := db.MarkAccountAsUnauthorized(acc.ID); err != nil {
+		log.Printf("[ACCOUNT AUTH CHECK] ошибка обновления статуса %s: %v", acc.Phone, err)
+	}
+	msg := fmt.Sprintf("номер %s больше не авторизован в программе", acc.Phone)
+	if err := db.SaveSos(msg); err != nil {
+		log.Printf("[ACCOUNT AUTH CHECK] ошибка записи в Sos: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- добавлен модуль проверки авторизации аккаунтов и обновление статуса
- подключен модуль к отключению подозрительных сессий
- опубликованы HTTP-маршруты для проверки авторизации

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a86beb2a0083278fd25913051fbbe1