### PR TITLE
Стандартизирован ответ ошибок HTTP

### DIFF
--- a/internal/comments/handler.go
+++ b/internal/comments/handler.go
@@ -1,6 +1,7 @@
 package comments
 
 import (
+	"atg_go/internal/httputil"
 	"atg_go/models"
 	"atg_go/pkg/storage"
 	"atg_go/pkg/telegram"
@@ -35,7 +36,7 @@ func (h *CommentHandler) SendComment(c *gin.Context) {
 
 	if err := c.ShouldBindJSON(&request); err != nil {
 		log.Printf("[HANDLER ERROR] Неверный формат запроса: %v", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request format"})
+		httputil.RespondError(c, http.StatusBadRequest, "Invalid request format")
 		return
 	}
 
@@ -44,7 +45,7 @@ func (h *CommentHandler) SendComment(c *gin.Context) {
 
 	if err != nil {
 		log.Printf("[HANDLER ERROR] Account lookup failed: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get accounts"})
+		httputil.RespondError(c, http.StatusInternalServerError, "Failed to get accounts")
 		return
 	}
 
@@ -61,7 +62,7 @@ func (h *CommentHandler) SendComment(c *gin.Context) {
 
 	if len(accounts) == 0 {
 		log.Printf("[HANDLER WARN] No authorized accounts with order found")
-		c.JSON(http.StatusNotFound, gin.H{"error": "No authorized ordered accounts available"})
+		httputil.RespondError(c, http.StatusNotFound, "No authorized ordered accounts available")
 		return
 	}
 
@@ -110,7 +111,7 @@ func (h *CommentHandler) SendComment(c *gin.Context) {
 		channelURL, err := h.CommentDB.GetRandomChannel(*account.OrderID)
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Printf("[HANDLER ERROR] No channels available: %v", err)
-			c.JSON(http.StatusNotFound, gin.H{"error": "No channels available"})
+			httputil.RespondError(c, http.StatusNotFound, "No channels available")
 			return
 		}
 		if err != nil {

--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -1,0 +1,9 @@
+package httputil
+
+import "github.com/gin-gonic/gin"
+
+// RespondError отправляет сообщение об ошибке в едином формате и прекращает обработку запроса.
+// Используем AbortWithStatusJSON, чтобы последующие обработчики не выполнялись, даже если забыли вернуть управление.
+func RespondError(c *gin.Context, status int, msg string) {
+	c.AbortWithStatusJSON(status, gin.H{"error": msg})
+}

--- a/internal/module/account_auth_check/handler.go
+++ b/internal/module/account_auth_check/handler.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 
+	"atg_go/internal/httputil"
 	"atg_go/pkg/storage"
 	authcheck "atg_go/pkg/telegram/module/account_auth_check"
 
@@ -26,7 +27,7 @@ func (h *Handler) Check(c *gin.Context) {
 	accounts, err := h.DB.GetAuthorizedAccounts()
 	if err != nil {
 		log.Printf("[ACCOUNT AUTH CHECK] ошибка получения аккаунтов: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		httputil.RespondError(c, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/internal/module/handler.go
+++ b/internal/module/handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sync"
 
+	"atg_go/internal/httputil"
 	"atg_go/pkg/storage"
 	telegrammodule "atg_go/pkg/telegram/module"
 
@@ -40,7 +41,7 @@ func (h *Handler) DispatcherActivity(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request format"})
+		httputil.RespondError(c, http.StatusBadRequest, "Invalid request format")
 		return
 	}
 
@@ -102,17 +103,17 @@ func (h *Handler) Unsubscribe(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "неверный формат запроса"})
+		httputil.RespondError(c, http.StatusBadRequest, "неверный формат запроса")
 		return
 	}
 
 	if len(req.Delay) != 2 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "delay должен содержать два значения"})
+		httputil.RespondError(c, http.StatusBadRequest, "delay должен содержать два значения")
 		return
 	}
 
 	if req.NumberChannelsOrGroups < 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "number_channels_or_groups должен быть неотрицательным числом"})
+		httputil.RespondError(c, http.StatusBadRequest, "number_channels_or_groups должен быть неотрицательным числом")
 		return
 	}
 
@@ -120,7 +121,7 @@ func (h *Handler) Unsubscribe(c *gin.Context) {
 	log.Printf("[UNSUBSCRIBE] запрос: delay=%v, count=%d", delayRange, req.NumberChannelsOrGroups)
 
 	if err := telegrammodule.ModF_UnsubscribeAll(h.DB, delayRange, req.NumberChannelsOrGroups); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		httputil.RespondError(c, http.StatusInternalServerError, err.Error())
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "completed"})
@@ -130,7 +131,7 @@ func (h *Handler) Unsubscribe(c *gin.Context) {
 func (h *Handler) OrderLinkUpdate(c *gin.Context) {
 	if err := telegrammodule.Modf_OrderLinkUpdate(h.DB); err != nil {
 		log.Printf("[HANDLER ERROR] обновление ссылок: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		httputil.RespondError(c, http.StatusInternalServerError, err.Error())
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "links updated"})

--- a/internal/order/handler.go
+++ b/internal/order/handler.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"strconv"
 
+	"atg_go/internal/httputil"
 	"atg_go/models"
 	"atg_go/pkg/storage"
 
@@ -26,14 +27,14 @@ func NewHandler(db *storage.DB) *Handler {
 func (h *Handler) CreateOrder(c *gin.Context) {
 	var o models.Order
 	if err := c.ShouldBindJSON(&o); err != nil {
-		c.JSON(400, gin.H{"error": "invalid data"})
+		httputil.RespondError(c, 400, "invalid data")
 		return
 	}
 
 	created, err := h.DB.CreateOrder(o)
 	if err != nil {
 		log.Printf("[ERROR] не удалось создать заказ: %v", err)
-		c.JSON(500, gin.H{"error": "db error"})
+		httputil.RespondError(c, 500, "db error")
 		return
 	}
 
@@ -44,7 +45,7 @@ func (h *Handler) CreateOrder(c *gin.Context) {
 func (h *Handler) GetCategories(c *gin.Context) {
 	names, err := h.DB.GetChannelNames()
 	if err != nil {
-		c.JSON(500, gin.H{"error": "db error"})
+		httputil.RespondError(c, 500, "db error")
 		return
 	}
 	c.JSON(200, gin.H{"categories": names})
@@ -57,13 +58,13 @@ func (h *Handler) UpdateAccountsNumber(c *gin.Context) {
 		AccountsNumberTheory int `json:"accounts_number_theory"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(400, gin.H{"error": "invalid data"})
+		httputil.RespondError(c, 400, "invalid data")
 		return
 	}
 	updated, err := h.DB.UpdateOrderAccountsNumber(id, input.AccountsNumberTheory)
 	if err != nil {
 		log.Printf("[ERROR] не удалось обновить заказ: %v", err)
-		c.JSON(500, gin.H{"error": "db error"})
+		httputil.RespondError(c, 500, "db error")
 		return
 	}
 	c.JSON(200, updated)
@@ -74,7 +75,7 @@ func (h *Handler) DeleteOrder(c *gin.Context) {
 	id, _ := strconv.Atoi(c.Param("id"))
 	if err := h.DB.DeleteOrder(id); err != nil {
 		log.Printf("[ERROR] не удалось удалить заказ: %v", err)
-		c.JSON(500, gin.H{"error": "db error"})
+		httputil.RespondError(c, 500, "db error")
 		return
 	}
 	c.JSON(200, gin.H{"status": "deleted"})

--- a/internal/reaction/handler.go
+++ b/internal/reaction/handler.go
@@ -1,6 +1,7 @@
 package reaction
 
 import (
+	"atg_go/internal/httputil"
 	"atg_go/models"
 	"atg_go/pkg/storage"
 	"atg_go/pkg/telegram"
@@ -38,7 +39,7 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 
 	if err := c.ShouldBindJSON(&request); err != nil {
 		log.Printf("[HANDLER ERROR] Неверный формат запроса: %v", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request format"})
+		httputil.RespondError(c, http.StatusBadRequest, "Invalid request format")
 		return
 	}
 
@@ -46,7 +47,7 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 	accounts, err := h.DB.GetAuthorizedAccounts()
 	if err != nil {
 		log.Printf("[HANDLER ERROR] Ошибка получения аккаунтов: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get accounts"})
+		httputil.RespondError(c, http.StatusInternalServerError, "Failed to get accounts")
 		return
 	}
 
@@ -62,7 +63,7 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 
 	if len(accounts) == 0 {
 		log.Printf("[HANDLER WARN] Нет авторизованных аккаунтов с заказом")
-		c.JSON(http.StatusNotFound, gin.H{"error": "No authorized ordered accounts available"})
+		httputil.RespondError(c, http.StatusNotFound, "No authorized ordered accounts available")
 		return
 	}
 
@@ -98,7 +99,7 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 		channelURL, err := h.CommentDB.GetRandomChannel(*account.OrderID)
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Printf("[HANDLER ERROR] Нет доступных каналов: %v", err)
-			c.JSON(http.StatusNotFound, gin.H{"error": "No channels available"})
+			httputil.RespondError(c, http.StatusNotFound, "No channels available")
 			return
 		}
 		if err != nil {

--- a/internal/statistics/handler.go
+++ b/internal/statistics/handler.go
@@ -1,6 +1,7 @@
 package statistics
 
 import (
+	"atg_go/internal/httputil"
 	"atg_go/pkg/storage"
 	stats "atg_go/pkg/telegram/statistics"
 	"log"
@@ -24,7 +25,7 @@ func (h *Handler) Collect(c *gin.Context) {
 	stat, err := stats.Calculate(h.DB)
 	if err != nil {
 		log.Printf("[HANDLER ERROR] не удалось посчитать статистику: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "не удалось посчитать статистику"})
+		httputil.RespondError(c, http.StatusInternalServerError, "не удалось посчитать статистику")
 		return
 	}
 	c.JSON(http.StatusOK, stat)


### PR DESCRIPTION
## Summary
- добавлен пакет `httputil` с функцией `RespondError`
- обработчики теперь используют `RespondError` вместо прямых `c.JSON(..., gin.H{"error": ...})`

## Testing
- `go fmt ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a87d3e2b7c8327adfcd835b2bcfb84