### PR TITLE
feat: вынести фильтрацию аккаунтов с заказом

### DIFF
--- a/internal/common/accounts.go
+++ b/internal/common/accounts.go
@@ -1,0 +1,19 @@
+package common
+
+import "atg_go/models"
+
+// NoOrderedAccountsMessage используется в обработчиках, чтобы единообразно
+// сообщать об отсутствии авторизованных аккаунтов, привязанных к заказу.
+const NoOrderedAccountsMessage = "No authorized ordered accounts available"
+
+// FilterAccountsWithOrder оставляет только те аккаунты, которые прикреплены к заказу.
+// Так мы исключаем «свободные» аккаунты из активностей.
+func FilterAccountsWithOrder(accounts []models.Account) []models.Account {
+	filtered := make([]models.Account, 0, len(accounts))
+	for _, acc := range accounts {
+		if acc.OrderID != nil {
+			filtered = append(filtered, acc)
+		}
+	}
+	return filtered
+}

--- a/internal/reaction/handler.go
+++ b/internal/reaction/handler.go
@@ -1,8 +1,8 @@
 package reaction
 
 import (
+	"atg_go/internal/common"
 	"atg_go/internal/httputil"
-	"atg_go/models"
 	"atg_go/pkg/storage"
 	"atg_go/pkg/telegram"
 	"database/sql"
@@ -51,19 +51,13 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 		return
 	}
 
-	// Фильтруем аккаунты, оставляя только те, что закреплены за заказом.
-	// Так мы предотвращаем участие свободных аккаунтов в активности.
-	var orderedAccounts []models.Account
-	for _, acc := range accounts {
-		if acc.OrderID != nil {
-			orderedAccounts = append(orderedAccounts, acc)
-		}
-	}
-	accounts = orderedAccounts
+	// Отбрасываем свободные аккаунты, оставляя только привязанные к заказу.
+	accounts = common.FilterAccountsWithOrder(accounts)
 
+	// Унифицированная обработка отсутствия подходящих аккаунтов.
 	if len(accounts) == 0 {
-		log.Printf("[HANDLER WARN] Нет авторизованных аккаунтов с заказом")
-		httputil.RespondError(c, http.StatusNotFound, "No authorized ordered accounts available")
+		log.Printf("[HANDLER WARN] %s", common.NoOrderedAccountsMessage)
+		httputil.RespondError(c, http.StatusNotFound, common.NoOrderedAccountsMessage)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- добавить общую функцию `FilterAccountsWithOrder`
- использовать её в обработчиках комментариев и реакций
- централизовать сообщение об отсутствии подходящих аккаунтов

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a891a1b8e88327a1f991e2b3c11ce4