### PR TITLE
refactor: split module handlers

### DIFF
--- a/internal/module/dispatcher.go
+++ b/internal/module/dispatcher.go
@@ -1,0 +1,65 @@
+package module
+
+import (
+	"context"
+	"net/http"
+
+	"atg_go/internal/httputil"
+	telegrammodule "atg_go/pkg/telegram/module"
+
+	"github.com/gin-gonic/gin"
+)
+
+// dispatcher.go содержит обработчики запуска и остановки задач диспетчера.
+// Вынос этих функций упрощает поддержку и разгружает основной файл обработчика.
+
+// DispatcherActivity запускает модульную активность диспатчера.
+// Помимо activity_request ожидает параметры запуска для разных типов действий.
+func (h *Handler) DispatcherActivity(c *gin.Context) {
+	var req struct {
+		DaysNumber                       int                                             `json:"days_number" binding:"required"`
+		ActivityRequest                  []telegrammodule.ActivityRequest                `json:"activity_request" binding:"required"`
+		ActivityComment                  telegrammodule.ActivitySettings                 `json:"activity_comment" binding:"required"`
+		ActivityReaction                 telegrammodule.ActivitySettings                 `json:"activity_reaction" binding:"required"`
+		ActivityAccountsUnsubscribe      telegrammodule.UnsubscribeSettings              `json:"activity_accounts_unsubscribe" binding:"required"`
+		ActivityActiveSessionsDisconnect telegrammodule.ActiveSessionsDisconnectSettings `json:"activity_active_sessions_disconnect" binding:"required"`
+	}
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.RespondError(c, http.StatusBadRequest, "Invalid request format")
+		return
+	}
+
+	// Запускаем задачу в отдельной горутине с возможностью отмены.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	h.mu.Lock()
+	id := h.next
+	h.next++
+	h.tasks[id] = cancel
+	h.mu.Unlock()
+
+	go func(taskID int) {
+		defer func() {
+			h.mu.Lock()
+			delete(h.tasks, taskID)
+			h.mu.Unlock()
+		}()
+		telegrammodule.ModF_DispatcherActivity(ctx, req.DaysNumber, req.ActivityRequest, req.ActivityComment, req.ActivityReaction, req.ActivityAccountsUnsubscribe, req.ActivityActiveSessionsDisconnect)
+	}(id)
+
+	c.JSON(http.StatusOK, gin.H{"status": "запущено", "task_id": id})
+}
+
+// CancelAllDispatcherActivity отменяет все активные задачи DispatcherActivity.
+func (h *Handler) CancelAllDispatcherActivity(c *gin.Context) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for id, cancel := range h.tasks {
+		cancel()
+		delete(h.tasks, id)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "все задачи остановлены"})
+}

--- a/internal/module/handler.go
+++ b/internal/module/handler.go
@@ -2,19 +2,14 @@ package module
 
 import (
 	"context"
-	"log"
-	"net/http"
 	"sync"
 
-	"atg_go/internal/httputil"
 	"atg_go/pkg/storage"
-	telegrammodule "atg_go/pkg/telegram/module"
-
-	"github.com/gin-gonic/gin"
 )
 
-// Handler обрабатывает запросы к модулю Telegram.
-// Handler обрабатывает запросы к модулю Telegram и хранит активные задачи.
+// handler.go содержит базовый обработчик модуля Telegram.
+// Здесь хранится общее состояние и доступ к БД, чтобы остальные обработчики
+// могли запускать фоновые задачи и пользоваться одной точкой входа.
 type Handler struct {
 	DB *storage.DB
 
@@ -23,116 +18,7 @@ type Handler struct {
 	next  int
 }
 
-// NewHandler создает новый экземпляр обработчика.
+// NewHandler создаёт новый экземпляр обработчика.
 func NewHandler(db *storage.DB) *Handler {
 	return &Handler{DB: db, tasks: make(map[int]context.CancelFunc)}
-}
-
-// DispatcherActivity запускает модульную активность диспатчера.
-// Помимо activity_request ожидает параметры запуска для разных типов действий.
-func (h *Handler) DispatcherActivity(c *gin.Context) {
-	var req struct {
-		DaysNumber                       int                                             `json:"days_number" binding:"required"`
-		ActivityRequest                  []telegrammodule.ActivityRequest                `json:"activity_request" binding:"required"`
-		ActivityComment                  telegrammodule.ActivitySettings                 `json:"activity_comment" binding:"required"`
-		ActivityReaction                 telegrammodule.ActivitySettings                 `json:"activity_reaction" binding:"required"`
-		ActivityAccountsUnsubscribe      telegrammodule.UnsubscribeSettings              `json:"activity_accounts_unsubscribe" binding:"required"`
-		ActivityActiveSessionsDisconnect telegrammodule.ActiveSessionsDisconnectSettings `json:"activity_active_sessions_disconnect" binding:"required"`
-	}
-
-	if err := c.ShouldBindJSON(&req); err != nil {
-		httputil.RespondError(c, http.StatusBadRequest, "Invalid request format")
-		return
-	}
-
-	// Запускаем задачу в отдельной горутине с возможностью отмены.
-	ctx, cancel := context.WithCancel(context.Background())
-
-	h.mu.Lock()
-	id := h.next
-	h.next++
-	h.tasks[id] = cancel
-	h.mu.Unlock()
-
-	go func(taskID int) {
-		defer func() {
-			h.mu.Lock()
-			delete(h.tasks, taskID)
-			h.mu.Unlock()
-		}()
-		telegrammodule.ModF_DispatcherActivity(ctx, req.DaysNumber, req.ActivityRequest, req.ActivityComment, req.ActivityReaction, req.ActivityAccountsUnsubscribe, req.ActivityActiveSessionsDisconnect)
-	}(id)
-
-	c.JSON(http.StatusOK, gin.H{"status": "запущено", "task_id": id})
-}
-
-// CancelAllDispatcherActivity отменяет все активные задачи DispatcherActivity.
-func (h *Handler) CancelAllDispatcherActivity(c *gin.Context) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	for id, cancel := range h.tasks {
-		cancel()
-		delete(h.tasks, id)
-	}
-
-	c.JSON(http.StatusOK, gin.H{"status": "все задачи остановлены"})
-}
-
-// Unsubscribe обрабатывает POST /module/unsubscribe.
-//
-// Запрос (JSON):
-//
-//	{
-//	  "delay": [min, max],               // массив из двух чисел с диапазоном задержки в секундах
-//	  "number_channels_or_groups": N     // количество каналов/групп (>= 0)
-//	}
-//
-// Ответ (200, JSON):
-// { "status": "completed" }
-//
-// Возможные ошибки:
-// - 400: неверный формат запроса
-// - 400: delay должен содержать два значения
-// - 400: number_channels_or_groups должен быть неотрицательным числом
-// - 500: внутренняя ошибка отписки
-func (h *Handler) Unsubscribe(c *gin.Context) {
-	var req struct {
-		Delay                  []int `json:"delay" binding:"required"`
-		NumberChannelsOrGroups int   `json:"number_channels_or_groups" binding:"required"`
-	}
-
-	if err := c.ShouldBindJSON(&req); err != nil {
-		httputil.RespondError(c, http.StatusBadRequest, "неверный формат запроса")
-		return
-	}
-
-	if len(req.Delay) != 2 {
-		httputil.RespondError(c, http.StatusBadRequest, "delay должен содержать два значения")
-		return
-	}
-
-	if req.NumberChannelsOrGroups < 0 {
-		httputil.RespondError(c, http.StatusBadRequest, "number_channels_or_groups должен быть неотрицательным числом")
-		return
-	}
-
-	delayRange := [2]int{req.Delay[0], req.Delay[1]}
-	log.Printf("[UNSUBSCRIBE] запрос: delay=%v, count=%d", delayRange, req.NumberChannelsOrGroups)
-
-	if err := telegrammodule.ModF_UnsubscribeAll(h.DB, delayRange, req.NumberChannelsOrGroups); err != nil {
-		httputil.RespondError(c, http.StatusInternalServerError, err.Error())
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"status": "completed"})
-}
-
-// OrderLinkUpdate обрабатывает запрос на обновление ссылок в описании аккаунтов
-func (h *Handler) OrderLinkUpdate(c *gin.Context) {
-	if err := telegrammodule.Modf_OrderLinkUpdate(h.DB); err != nil {
-		log.Printf("[HANDLER ERROR] обновление ссылок: %v", err)
-		httputil.RespondError(c, http.StatusInternalServerError, err.Error())
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"status": "links updated"})
 }

--- a/internal/module/order_link_update.go
+++ b/internal/module/order_link_update.go
@@ -1,0 +1,24 @@
+package module
+
+import (
+	"log"
+	"net/http"
+
+	"atg_go/internal/httputil"
+	telegrammodule "atg_go/pkg/telegram/module"
+
+	"github.com/gin-gonic/gin"
+)
+
+// order_link_update.go обновляет ссылки в описании аккаунтов.
+// Выделение логики в отдельный файл упрощает поиск обработчиков по задачам.
+
+// OrderLinkUpdate обрабатывает запрос на обновление ссылок в описании аккаунтов.
+func (h *Handler) OrderLinkUpdate(c *gin.Context) {
+	if err := telegrammodule.Modf_OrderLinkUpdate(h.DB); err != nil {
+		log.Printf("[HANDLER ERROR] обновление ссылок: %v", err)
+		httputil.RespondError(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "links updated"})
+}

--- a/internal/module/unsubscribe.go
+++ b/internal/module/unsubscribe.go
@@ -1,0 +1,62 @@
+package module
+
+import (
+	"log"
+	"net/http"
+
+	"atg_go/internal/httputil"
+	telegrammodule "atg_go/pkg/telegram/module"
+
+	"github.com/gin-gonic/gin"
+)
+
+// unsubscribe.go отвечает за обработку массовой отписки от каналов и групп.
+// Отдельный файл позволяет легче ориентироваться в коде модуля.
+
+// Unsubscribe обрабатывает POST /module/unsubscribe.
+//
+// Запрос (JSON):
+//
+//	{
+//	  "delay": [min, max],               // массив из двух чисел с диапазоном задержки в секундах
+//	  "number_channels_or_groups": N     // количество каналов/групп (>= 0)
+//	}
+//
+// Ответ (200, JSON):
+// { "status": "completed" }
+//
+// Возможные ошибки:
+// - 400: неверный формат запроса
+// - 400: delay должен содержать два значения
+// - 400: number_channels_or_groups должен быть неотрицательным числом
+// - 500: внутренняя ошибка отписки
+func (h *Handler) Unsubscribe(c *gin.Context) {
+	var req struct {
+		Delay                  []int `json:"delay" binding:"required"`
+		NumberChannelsOrGroups int   `json:"number_channels_or_groups" binding:"required"`
+	}
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.RespondError(c, http.StatusBadRequest, "неверный формат запроса")
+		return
+	}
+
+	if len(req.Delay) != 2 {
+		httputil.RespondError(c, http.StatusBadRequest, "delay должен содержать два значения")
+		return
+	}
+
+	if req.NumberChannelsOrGroups < 0 {
+		httputil.RespondError(c, http.StatusBadRequest, "number_channels_or_groups должен быть неотрицательным числом")
+		return
+	}
+
+	delayRange := [2]int{req.Delay[0], req.Delay[1]}
+	log.Printf("[UNSUBSCRIBE] запрос: delay=%v, count=%d", delayRange, req.NumberChannelsOrGroups)
+
+	if err := telegrammodule.ModF_UnsubscribeAll(h.DB, delayRange, req.NumberChannelsOrGroups); err != nil {
+		httputil.RespondError(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "completed"})
+}


### PR DESCRIPTION
## Summary
- split dispatcher handlers into separate file
- move unsubscribe handler to its own file
- isolate order link update handler

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a89655f51c8327a776b091d28d44c7