### PR TITLE
Добавить флаг мониторинга аккаунта

### DIFF
--- a/migrations/account_monitoring.sql
+++ b/migrations/account_monitoring.sql
@@ -1,0 +1,4 @@
+-- Флаг мониторинга: добавляем колонку, чтобы управлять наблюдением за аккаунтом.
+-- По умолчанию не включаем мониторинг, чтобы не выполнять лишнюю работу.
+ALTER TABLE accounts
+    ADD COLUMN account_monitoring BOOLEAN NOT NULL DEFAULT false;

--- a/models/account.go
+++ b/models/account.go
@@ -3,14 +3,15 @@ package models
 import "github.com/lib/pq"
 
 type Account struct {
-	ID            int            `json:"id"`
-	Phone         string         `json:"phone"`
-	ApiID         int            `json:"api_id"`
-	ApiHash       string         `json:"api_hash"`
-	IsAuthorized  bool           `json:"is_authorized"`
-	Gender        pq.StringArray `json:"gender"` // Пол(ы) аккаунта: допускается несколько значений
-	PhoneCodeHash string         `json:"phone_code_hash"`
-	ProxyID       *int           `json:"proxy_id"`
-	OrderID       *int           `json:"order_id"` // ID выполняемого заказа (NULL, если аккаунт свободен)
-	Proxy         *Proxy         `json:"proxy"`
+	ID                int            `json:"id"`
+	Phone             string         `json:"phone"`
+	ApiID             int            `json:"api_id"`
+	ApiHash           string         `json:"api_hash"`
+	IsAuthorized      bool           `json:"is_authorized"`
+	AccountMonitoring bool           `json:"account_monitoring"` // Включает мониторинг аккаунта; по умолчанию false для экономии ресурсов
+	Gender            pq.StringArray `json:"gender"`             // Пол(ы) аккаунта: допускается несколько значений
+	PhoneCodeHash     string         `json:"phone_code_hash"`
+	ProxyID           *int           `json:"proxy_id"`
+	OrderID           *int           `json:"order_id"` // ID выполняемого заказа (NULL, если аккаунт свободен)
+	Proxy             *Proxy         `json:"proxy"`
 }


### PR DESCRIPTION
## Summary
- добавить в структуру Account поле `AccountMonitoring`
- добавить миграцию с колонкой `account_monitoring` по умолчанию `false`

## Testing
- `gofmt -w models/account.go`
- `go vet ./...` *(прервано: процесс завис)*
- `go test ./...` *(прервано: процесс завис)*

------
https://chatgpt.com/codex/tasks/task_e_68ab749d30508327884b8061383a889f