### PR TITLE
Исключаем мониторинговые аккаунты из реакций и комментариев

### DIFF
--- a/internal/comments/handler.go
+++ b/internal/comments/handler.go
@@ -50,6 +50,9 @@ func (h *CommentHandler) SendComment(c *gin.Context) {
 	// Фильтруем аккаунты, оставляя только закреплённые за заказом.
 	accounts = common.FilterAccountsWithOrder(accounts)
 
+	// Исключаем аккаунты, используемые для мониторинга, чтобы не мешать их основной задаче.
+	accounts = common.FilterAccountsWithoutMonitoring(accounts)
+
 	// Если ни один аккаунт не найден, возвращаем единообразную ошибку.
 	if len(accounts) == 0 {
 		log.Printf("[HANDLER WARN] %s", common.NoOrderedAccountsMessage)

--- a/internal/common/accounts.go
+++ b/internal/common/accounts.go
@@ -17,3 +17,15 @@ func FilterAccountsWithOrder(accounts []models.Account) []models.Account {
 	}
 	return filtered
 }
+
+// FilterAccountsWithoutMonitoring исключает аккаунты, для которых включён мониторинг.
+// Такие аккаунты выполняют только вспомогательные задачи и не должны участвовать в активностях.
+func FilterAccountsWithoutMonitoring(accounts []models.Account) []models.Account {
+	filtered := make([]models.Account, 0, len(accounts))
+	for _, acc := range accounts {
+		if !acc.AccountMonitoring {
+			filtered = append(filtered, acc)
+		}
+	}
+	return filtered
+}

--- a/internal/reaction/handler.go
+++ b/internal/reaction/handler.go
@@ -52,6 +52,9 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 	// Отбрасываем свободные аккаунты, оставляя только привязанные к заказу.
 	accounts = common.FilterAccountsWithOrder(accounts)
 
+	// Исключаем аккаунты с включённым мониторингом, чтобы они не тратили лимиты на реакции.
+	accounts = common.FilterAccountsWithoutMonitoring(accounts)
+
 	// Унифицированная обработка отсутствия подходящих аккаунтов.
 	if len(accounts) == 0 {
 		log.Printf("[HANDLER WARN] %s", common.NoOrderedAccountsMessage)


### PR DESCRIPTION
## Summary
- добавлен фильтр аккаунтов с мониторингом
- исключены мониторинговые аккаунты из реакций и комментариев

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab809c579c832795d9af8bcdb92974