### PR TITLE
Запрет мониторинговых аккаунтов выполнять заказы

### DIFF
--- a/migrations/account_monitoring_order_constraint.sql
+++ b/migrations/account_monitoring_order_constraint.sql
@@ -1,0 +1,9 @@
+-- Аккаунты с мониторингом не должны выполнять заказы.
+-- Сначала снимаем их с текущих заказов, затем добавляем ограничение.
+UPDATE accounts
+SET order_id = NULL
+WHERE account_monitoring = TRUE AND order_id IS NOT NULL;
+
+ALTER TABLE accounts
+    ADD CONSTRAINT account_monitoring_no_order
+    CHECK (NOT account_monitoring OR order_id IS NULL);

--- a/models/account.go
+++ b/models/account.go
@@ -8,7 +8,7 @@ type Account struct {
 	ApiID             int            `json:"api_id"`
 	ApiHash           string         `json:"api_hash"`
 	IsAuthorized      bool           `json:"is_authorized"`
-	AccountMonitoring bool           `json:"account_monitoring"` // Включает мониторинг аккаунта; по умолчанию false для экономии ресурсов
+	AccountMonitoring bool           `json:"account_monitoring"` // Включает мониторинг аккаунта; такие аккаунты не назначаются на заказы
 	Gender            pq.StringArray `json:"gender"`             // Пол(ы) аккаунта: допускается несколько значений
 	PhoneCodeHash     string         `json:"phone_code_hash"`
 	ProxyID           *int           `json:"proxy_id"`

--- a/pkg/storage/order.go
+++ b/pkg/storage/order.go
@@ -87,9 +87,10 @@ func (db *DB) CreateOrder(o models.Order) (*models.Order, error) {
 	}
 	o.Gender = gender
 
-	// Выбираем свободные аккаунты в случайном порядке
+	// Выбираем свободные аккаунты, исключая мониторинговые,
+	// чтобы такие аккаунты не становились исполнителями заказов
 	rows, err := tx.Query(
-		`SELECT id FROM accounts WHERE order_id IS NULL ORDER BY RANDOM() LIMIT $1`,
+		`SELECT id FROM accounts WHERE order_id IS NULL AND account_monitoring = FALSE ORDER BY RANDOM() LIMIT $1`,
 		o.AccountsNumberTheory,
 	)
 	if err != nil {
@@ -144,9 +145,9 @@ func (db *DB) UpdateOrderAccountsNumber(orderID, newNumber int) (*models.Order, 
 	o.AccountsNumberTheory = newNumber
 
 	if newNumber > o.AccountsNumberFact {
-		// Добавляем недостающие аккаунты
+		// Добавляем недостающие аккаунты, игнорируя аккаунты под мониторингом
 		diff := newNumber - o.AccountsNumberFact
-		rows, err := tx.Query(`SELECT id FROM accounts WHERE order_id IS NULL ORDER BY RANDOM() LIMIT $1`, diff)
+		rows, err := tx.Query(`SELECT id FROM accounts WHERE order_id IS NULL AND account_monitoring = FALSE ORDER BY RANDOM() LIMIT $1`, diff)
 		if err != nil {
 			return nil, err
 		}
@@ -327,7 +328,7 @@ func (db *DB) AssignFreeAccountsToOrders() error {
 				// Нужно добавить недостающие аккаунты
 				need := theory - actual
 				accRows, err := tx.Query(
-					`SELECT id FROM accounts WHERE order_id IS NULL AND is_authorized = TRUE AND gender && $1::gender_enum[] ORDER BY RANDOM() LIMIT $2`,
+					`SELECT id FROM accounts WHERE order_id IS NULL AND is_authorized = TRUE AND account_monitoring = FALSE AND gender && $1::gender_enum[] ORDER BY RANDOM() LIMIT $2`,
 					pq.Array(genders), need,
 				)
 				if err != nil {

--- a/pkg/telegram/module/link_update.go
+++ b/pkg/telegram/module/link_update.go
@@ -16,6 +16,12 @@ import (
 // Если order_id есть, в описание ставится текст из поля url_description соответствующего заказа,
 // иначе описание очищается. Комментарии на русском языке по требованию пользователя.
 func Modf_OrderLinkUpdate(db *storage.DB) error {
+	// Сначала освобождаем аккаунты под мониторингом, если они случайно привязаны к заказам
+	if err := db.ReleaseMonitoringAccounts(); err != nil {
+		log.Printf("[LINK_UPDATE ERROR] освобождение мониторинговых аккаунтов: %v", err)
+		return err
+	}
+
 	// Перед обновлением описаний синхронизируем количество аккаунтов в заказах
 	if err := db.AssignFreeAccountsToOrders(); err != nil {
 		log.Printf("[LINK_UPDATE ERROR] назначение аккаунтов: %v", err)


### PR DESCRIPTION
## Summary
- исключены мониторинговые аккаунты из выборок для заказов и списка авторизованных
- при обновлении ссылок освобождаются аккаунты с мониторингом
- добавлено ограничение БД, запрещающее назначение мониторинговых аккаунтов на заказы

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab840271c48327a13fd18ea6ca5353