### PR TITLE
Разделение метрик активности в channel_post

### DIFF
--- a/migrations/2025-08-25-1200_update_channel_post_metrics.sql
+++ b/migrations/2025-08-25-1200_update_channel_post_metrics.sql
@@ -1,0 +1,6 @@
+-- Разделяем требования по активной аудитории на отдельные метрики
+ALTER TABLE channel_post
+    DROP COLUMN subs_active_all,
+    ADD COLUMN subs_active_view INTEGER,
+    ADD COLUMN subs_active_reaction INTEGER,
+    ADD COLUMN subs_active_repost INTEGER;

--- a/models/channel_post.go
+++ b/models/channel_post.go
@@ -13,6 +13,10 @@ type ChannelPost struct {
 	OrderID      int       `json:"order_id"`
 	PostDateTime time.Time `json:"post_date_time"`
 	PostURL      string    `json:"post_url"`
-	// SubsActiveAll фиксирует активных подписчиков для оценки охвата; NULL если данных нет
-	SubsActiveAll *int `json:"subs_active_all"`
+	// SubsActiveView отражает требуемое число просмотров поста; nil если заказ не ставит цель
+	SubsActiveView *int `json:"subs_active_view"`
+	// SubsActiveReaction хранит целевое количество реакций; nil когда заказ не задаёт метрику
+	SubsActiveReaction *int `json:"subs_active_reaction"`
+	// SubsActiveRepost фиксирует требуемые репосты; nil при отсутствии требования
+	SubsActiveRepost *int `json:"subs_active_repost"`
 }


### PR DESCRIPTION
## Summary
- удалить устаревшее поле subs_active_all
- добавить отдельные поля для просмотров, реакций и репостов поста

## Testing
- `go test ./...` *(hanging)*

------
https://chatgpt.com/codex/tasks/task_e_68ac58ee00188327b1236457e06a0f40