### PR TITLE
Добавлен мониторинг каналов заказов

### DIFF
--- a/internal/module/monitoring/monitoring.go
+++ b/internal/module/monitoring/monitoring.go
@@ -1,0 +1,12 @@
+package monitoring
+
+import (
+	"atg_go/pkg/storage"
+	tgmonitor "atg_go/pkg/telegram/module/monitoring"
+)
+
+// Run запускает фоновый мониторинг каналов заказов.
+// Работает пока активен сервер.
+func Run(db *storage.DB) {
+	tgmonitor.Start(db)
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"atg_go/internal/comments"
 	"atg_go/internal/middleware"
 	module "atg_go/internal/module"
+	monitoring "atg_go/internal/module/monitoring"
 	orders "atg_go/internal/order"
 	reaction "atg_go/internal/reaction"
 	statistics "atg_go/internal/statistics"
@@ -38,6 +39,9 @@ func main() {
 	// Инициализация хранилищ
 	db := storage.NewDB(dbConn)               // Для работы с аккаунтами
 	commentDB := storage.NewCommentDB(dbConn) // Для работы с каналами
+
+	// Запускаем фоновый мониторинг каналов заказов
+	monitoring.Run(db)
 
 	// Настройка роутера
 	r := setupRouter(db, commentDB)

--- a/pkg/storage/channel_post.go
+++ b/pkg/storage/channel_post.go
@@ -1,0 +1,17 @@
+package storage
+
+import (
+	"atg_go/models"
+	"log"
+)
+
+// CreateChannelPost сохраняет информацию о новом посте канала в БД.
+// Используется мониторингом для фиксации публикаций заказов.
+func (db *DB) CreateChannelPost(p models.ChannelPost) error {
+	_, err := db.Conn.Exec(`INSERT INTO channel_post (order_id, post_date_time, post_url) VALUES ($1, $2, $3)`,
+		p.OrderID, p.PostDateTime, p.PostURL)
+	if err != nil {
+		log.Printf("[DB ERROR] сохранение поста: %v", err)
+	}
+	return err
+}

--- a/pkg/storage/order.go
+++ b/pkg/storage/order.go
@@ -48,6 +48,29 @@ func (db *DB) GetOrdersDefaultURLs() ([]string, error) {
 	return urls, nil
 }
 
+// GetOrdersForMonitoring возвращает заказы с их ссылками и ID каналов.
+// Эти данные нужны мониторинговым аккаунтам для подписки на каналы.
+func (db *DB) GetOrdersForMonitoring() ([]models.Order, error) {
+	rows, err := db.Conn.Query(`SELECT id, url_default, channel_tgid FROM orders WHERE url_default <> ''`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var orders []models.Order
+	for rows.Next() {
+		var o models.Order
+		if err := rows.Scan(&o.ID, &o.URLDefault, &o.ChannelTGID); err != nil {
+			return nil, err
+		}
+		orders = append(orders, o)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return orders, nil
+}
+
 // GetOrdersWithoutChannelTGID возвращает заказы без заполненного channel_tgid
 // Используется перед обновлением описаний, чтобы знать, какие заказы требуют дополнения
 func (db *DB) GetOrdersWithoutChannelTGID() ([]models.Order, error) {

--- a/pkg/telegram/auth/auth.go
+++ b/pkg/telegram/auth/auth.go
@@ -49,7 +49,7 @@ func (a AuthHelper) AcceptTermsOfService(ctx context.Context, tos tg.HelpTermsOf
 
 // RequestCode отправляет код подтверждения и сохраняет хеш в БД
 func RequestCode(apiID int, apiHash, phone string, proxy *models.Proxy, db *storage.DB, accountID int) (string, error) {
-	client, err := module.Modf_AccountInitialization(apiID, apiHash, phone, proxy, nil, db.Conn, accountID)
+	client, err := module.Modf_AccountInitialization(apiID, apiHash, phone, proxy, nil, db.Conn, accountID, nil)
 	if err != nil {
 		return "", err
 	}
@@ -77,7 +77,7 @@ func RequestCode(apiID int, apiHash, phone string, proxy *models.Proxy, db *stor
 
 func CompleteAuthorization(db *storage.DB, accountID, apiID int, apiHash, phone, code, phoneCodeHash string, proxy *models.Proxy) error {
 	randSrc := rand.New(rand.NewSource(time.Now().UnixNano()))
-	client, err := module.Modf_AccountInitialization(apiID, apiHash, phone, proxy, randSrc, db.Conn, accountID)
+	client, err := module.Modf_AccountInitialization(apiID, apiHash, phone, proxy, randSrc, db.Conn, accountID, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/telegram/comment/comment.go
+++ b/pkg/telegram/comment/comment.go
@@ -41,7 +41,7 @@ func SendComment(db *storage.DB, accountID int, phone, channelURL string, apiID 
 	}
 
 	// Создаем клиент Telegram с указанными параметрами
-	client, err := module.Modf_AccountInitialization(apiID, apiHash, phone, proxy, nil, db.Conn, accountID)
+	client, err := module.Modf_AccountInitialization(apiID, apiHash, phone, proxy, nil, db.Conn, accountID, nil)
 	if err != nil {
 		// При ошибке инициализации также возвращаем нулевые идентификаторы
 		return 0, 0, err

--- a/pkg/telegram/module/account_auth_check/check.go
+++ b/pkg/telegram/module/account_auth_check/check.go
@@ -17,7 +17,7 @@ import (
 // При отсутствии сессии или ошибке Telegram фиксируем событие в Sos
 // и сбрасываем флаг авторизации.
 func Check(db *storage.DB, acc models.Account) bool {
-	client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID)
+	client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, nil)
 	if err != nil {
 		// Инициализация клиента без сессии невозможна, считаем аккаунт неавторизованным.
 		log.Printf("[ACCOUNT AUTH CHECK] аккаунт %s: ошибка инициализации: %v", acc.Phone, err)

--- a/pkg/telegram/module/active_sessions_disconnect/disconnect.go
+++ b/pkg/telegram/module/active_sessions_disconnect/disconnect.go
@@ -44,7 +44,7 @@ func DisconnectSuspiciousSessions(db *storage.DB, minDelay, maxDelay int) (map[s
 			time.Sleep(time.Duration(delay) * time.Second)
 		}
 
-		client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID)
+		client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, nil)
 		if err != nil {
 			// Не прерываем работу из-за одного аккаунта, чтобы обработать остальные
 			log.Printf("[ACTIVE SESSIONS DISCONNECT] аккаунт %s: ошибка инициализации: %v", acc.Phone, err)

--- a/pkg/telegram/module/active_sessions_disconnect/info.go
+++ b/pkg/telegram/module/active_sessions_disconnect/info.go
@@ -37,7 +37,7 @@ func LogAuthorizations(db *storage.DB) error {
 
 	// Для каждого выбранного аккаунта инициализируем клиента и выводим его активные сессии
 	for _, acc := range accounts[:limit] {
-		client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID)
+		client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, nil)
 		if err != nil {
 			// Не прерываем обработку остальных аккаунтов, чтобы увидеть информацию хотя бы по части из них
 			log.Printf("[ACTIVE SESSIONS] аккаунт %d (%s): ошибка инициализации: %v", acc.ID, acc.Phone, err)

--- a/pkg/telegram/module/channel_utils.go
+++ b/pkg/telegram/module/channel_utils.go
@@ -117,13 +117,16 @@ func Modf_FindChannel(chats []tg.ChatClass) (*tg.Channel, error) {
 }
 
 // Создаем клиент Telegram с указанными параметрами и хранилищем сессии в БД.
-func Modf_AccountInitialization(apiID int, apiHash, phone string, p *models.Proxy, r *rand.Rand, db *sql.DB, accountID int) (*telegram.Client, error) {
+func Modf_AccountInitialization(apiID int, apiHash, phone string, p *models.Proxy, r *rand.Rand, db *sql.DB, accountID int, h telegram.UpdateHandler) (*telegram.Client, error) {
 	var storage session.Storage = &session.StorageMemory{}
 	if db != nil && accountID > 0 {
 		storage = &DBSessionStorage{DB: db, AccountID: accountID}
 	}
 
 	opts := telegram.Options{SessionStorage: storage}
+	if h != nil {
+		opts.UpdateHandler = h
+	}
 	if r != nil {
 		opts.Random = r
 	}

--- a/pkg/telegram/module/link_update.go
+++ b/pkg/telegram/module/link_update.go
@@ -69,7 +69,7 @@ func updateAccountDescription(db *storage.DB, acc models.Account, description st
 	defer accountmutex.UnlockAccount(acc.ID)
 
 	// Инициализируем клиента Telegram
-	client, err := Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID)
+	client, err := Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/telegram/module/monitoring/monitoring.go
+++ b/pkg/telegram/module/monitoring/monitoring.go
@@ -1,0 +1,127 @@
+package monitoring
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"atg_go/models"
+	"atg_go/pkg/storage"
+	base "atg_go/pkg/telegram/module"
+	accountmutex "atg_go/pkg/telegram/module/account_mutex"
+
+	"github.com/gotd/td/tg"
+)
+
+type orderInfo struct {
+	id  int
+	url string
+}
+
+// Start запускает отслеживание новых постов на каналах заказов.
+// Используется первым доступным мониторинг-аккаунтом.
+func Start(db *storage.DB) {
+	go func() {
+		if err := run(db); err != nil {
+			log.Printf("[MONITORING] остановлено: %v", err)
+		}
+	}()
+}
+
+// run выполняет инициализацию клиента Telegram и обрабатывает обновления.
+func run(db *storage.DB) error {
+	accounts, err := db.GetMonitoringAccounts()
+	if err != nil {
+		return err
+	}
+	if len(accounts) == 0 {
+		return fmt.Errorf("нет аккаунтов для мониторинга")
+	}
+	acc := accounts[0]
+
+	if err := accountmutex.LockAccount(acc.ID); err != nil {
+		return err
+	}
+	defer accountmutex.UnlockAccount(acc.ID)
+
+	orders, err := db.GetOrdersForMonitoring()
+	if err != nil {
+		return err
+	}
+
+	dispatcher := tg.NewUpdateDispatcher()
+	orderMap := make(map[int64]orderInfo)
+
+	dispatcher.OnNewChannelMessage(func(ctx context.Context, e tg.Entities, upd *tg.UpdateNewChannelMessage) error {
+		msg, ok := upd.Message.(*tg.Message)
+		if !ok {
+			return nil
+		}
+		peer, ok := msg.PeerID.(*tg.PeerChannel)
+		if !ok {
+			return nil
+		}
+		if o, ok := orderMap[peer.ChannelID]; ok {
+			postTime := time.Unix(int64(msg.Date), 0)
+			link := strings.TrimSuffix(o.url, "/") + "/" + strconv.Itoa(msg.ID)
+			cp := models.ChannelPost{OrderID: o.id, PostDateTime: postTime, PostURL: link}
+			if err := db.CreateChannelPost(cp); err != nil {
+				log.Printf("[MONITORING] сохранение поста: %v", err)
+			}
+		}
+		return nil
+	})
+
+	client, err := base.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, dispatcher)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	return client.Run(ctx, func(ctx context.Context) error {
+		api := tg.NewClient(client)
+
+		// Подписываемся на каналы и включаем уведомления
+		for _, o := range orders {
+			username, err := base.Modf_ExtractUsername(o.URLDefault)
+			if err != nil {
+				log.Printf("[MONITORING] некорректная ссылка %s: %v", o.URLDefault, err)
+				continue
+			}
+			resolved, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: username})
+			if err != nil {
+				log.Printf("[MONITORING] не удалось получить канал %s: %v", o.URLDefault, err)
+				continue
+			}
+			ch, err := base.Modf_FindChannel(resolved.GetChats())
+			if err != nil {
+				log.Printf("[MONITORING] канал %s не найден: %v", o.URLDefault, err)
+				continue
+			}
+			if err := base.Modf_JoinChannel(ctx, api, ch, db, acc.ID); err != nil && !strings.Contains(err.Error(), "USER_ALREADY_PARTICIPANT") {
+				log.Printf("[MONITORING] подписка на %s: %v", o.URLDefault, err)
+			}
+			settings := tg.InputPeerNotifySettings{}
+			settings.SetMuteUntil(0)
+			_, err = api.AccountUpdateNotifySettings(ctx, &tg.AccountUpdateNotifySettingsRequest{
+				Peer:     &tg.InputNotifyPeer{Peer: &tg.InputPeerChannel{ChannelID: ch.ID, AccessHash: ch.AccessHash}},
+				Settings: settings,
+			})
+			if err != nil {
+				log.Printf("[MONITORING] уведомления %s: %v", o.URLDefault, err)
+			}
+			if o.ChannelTGID == nil {
+				_ = db.SetOrderChannelTGID(o.ID, fmt.Sprintf("%d", ch.ID))
+			}
+			orderMap[ch.ID] = orderInfo{id: o.ID, url: o.URLDefault}
+		}
+
+		// держим соединение активным, пока контекст не будет отменён
+		<-ctx.Done()
+		return nil
+	})
+}

--- a/pkg/telegram/module/order_tgid_update.go
+++ b/pkg/telegram/module/order_tgid_update.go
@@ -52,7 +52,7 @@ func Modf_UpdateOrdersChannelTGID(db *storage.DB) error {
 	}
 	defer accountmutex.UnlockAccount(acc.ID)
 
-	client, err := Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID)
+	client, err := Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/telegram/module/unsubscribe.go
+++ b/pkg/telegram/module/unsubscribe.go
@@ -49,7 +49,7 @@ func ModF_UnsubscribeAll(db *storage.DB, delay [2]int, limit int) error {
 
 // unsubscribeAccount выходит из указанного количества каналов и групп для одного аккаунта.
 func unsubscribeAccount(db *storage.DB, acc *models.Account, delay [2]int, limit int, skip map[string]struct{}) error {
-	client, err := Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID)
+	client, err := Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/telegram/reaction/reaction.go
+++ b/pkg/telegram/reaction/reaction.go
@@ -39,7 +39,7 @@ func SendReaction(db *storage.DB, accountID int, phone, channelURL string, apiID
 		return 0, 0, fmt.Errorf("не удалось извлечь имя пользователя: %w", err)
 	}
 
-	client, err := module.Modf_AccountInitialization(apiID, apiHash, phone, proxy, nil, db.Conn, accountID)
+	client, err := module.Modf_AccountInitialization(apiID, apiHash, phone, proxy, nil, db.Conn, accountID, nil)
 	if err != nil {
 		// При ошибке инициализации возвращаем нулевые идентификаторы
 		return 0, 0, err

--- a/pkg/telegram/user/user.go
+++ b/pkg/telegram/user/user.go
@@ -16,7 +16,7 @@ import (
 
 // GetUserID возвращает ID пользователя Telegram для указанного аккаунта
 func GetUserID(db *storage.DB, accountID int, phone string, apiID int, apiHash string, proxy *models.Proxy) (int, error) {
-	client, err := module.Modf_AccountInitialization(apiID, apiHash, phone, proxy, nil, db.Conn, accountID)
+	client, err := module.Modf_AccountInitialization(apiID, apiHash, phone, proxy, nil, db.Conn, accountID, nil)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Summary
- реализован фоновый мониторинг каналов заказов и запись постов в ChannelPost
- добавлены методы для выборки мониторинговых аккаунтов и каналов заказов
- сервер запускает мониторинг при старте

## Testing
- `go test ./...` *(завершилось успешно для пакета storage)*

------
https://chatgpt.com/codex/tasks/task_e_68acae83253c83279e9ddd9b0b8ec4cb