### PR TITLE
Рассчитываем метрики активной аудитории постов

### DIFF
--- a/pkg/storage/channel_post.go
+++ b/pkg/storage/channel_post.go
@@ -6,10 +6,10 @@ import (
 )
 
 // CreateChannelPost сохраняет информацию о новом посте канала в БД.
-// Используется мониторингом для фиксации публикаций заказов.
+// Используется мониторингом для фиксации публикаций заказов с расчётом активной аудитории.
 func (db *DB) CreateChannelPost(p models.ChannelPost) error {
-	_, err := db.Conn.Exec(`INSERT INTO channel_post (order_id, post_date_time, post_url) VALUES ($1, $2, $3)`,
-		p.OrderID, p.PostDateTime, p.PostURL)
+	_, err := db.Conn.Exec(`INSERT INTO channel_post (order_id, post_date_time, post_url, subs_active_view, subs_active_reaction, subs_active_repost) VALUES ($1, $2, $3, $4, $5, $6)`,
+		p.OrderID, p.PostDateTime, p.PostURL, p.SubsActiveView, p.SubsActiveReaction, p.SubsActiveRepost)
 	if err != nil {
 		log.Printf("[DB ERROR] сохранение поста: %v", err)
 	}

--- a/pkg/storage/order.go
+++ b/pkg/storage/order.go
@@ -48,10 +48,10 @@ func (db *DB) GetOrdersDefaultURLs() ([]string, error) {
 	return urls, nil
 }
 
-// GetOrdersForMonitoring возвращает заказы с их ссылками и ID каналов.
-// Эти данные нужны мониторинговым аккаунтам для подписки на каналы.
+// GetOrdersForMonitoring возвращает заказы с их ссылками, ID каналов и числом активной аудитории.
+// Эти данные нужны мониторинговым аккаунтам для подписки на каналы и расчёта метрик постов.
 func (db *DB) GetOrdersForMonitoring() ([]models.Order, error) {
-	rows, err := db.Conn.Query(`SELECT id, url_default, channel_tgid FROM orders WHERE url_default <> ''`)
+	rows, err := db.Conn.Query(`SELECT id, url_default, channel_tgid, subs_active_count FROM orders WHERE url_default <> ''`)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (db *DB) GetOrdersForMonitoring() ([]models.Order, error) {
 	var orders []models.Order
 	for rows.Next() {
 		var o models.Order
-		if err := rows.Scan(&o.ID, &o.URLDefault, &o.ChannelTGID); err != nil {
+		if err := rows.Scan(&o.ID, &o.URLDefault, &o.ChannelTGID, &o.SubsActiveCount); err != nil {
 			return nil, err
 		}
 		orders = append(orders, o)


### PR DESCRIPTION
## Summary
- Расчёт SubsActiveView, SubsActiveReaction и SubsActiveRepost при фиксации постов мониторингом
- Хранение численности активной аудитории для расчёта метрик
- Сохранение рассчитанных значений в таблице channel_post

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68acd549ff148327814fca4d7a00df95