### PR TITLE
Add channel_post_theory table

### DIFF
--- a/migrations/2025-08-25-2200_add_channel_post_theory.sql
+++ b/migrations/2025-08-25-2200_add_channel_post_theory.sql
@@ -1,0 +1,9 @@
+-- Таблица прогнозов просмотров по группам часов для поста канала
+CREATE TABLE IF NOT EXISTS channel_post_theory (
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- современный автоинкремент
+    channel_post_id INTEGER NOT NULL REFERENCES channel_post(id) ON DELETE CASCADE, -- связь с конкретным постом
+    view_4group_theory DOUBLE PRECISION NOT NULL DEFAULT 0, -- Часы: 7–24 → 0.5–3.2%
+    view_3group_theory DOUBLE PRECISION NOT NULL DEFAULT 0, -- Часы: 4–6 → 3.7–6.3%
+    view_2group_theory DOUBLE PRECISION NOT NULL DEFAULT 0, -- Часы: 2–3 → 6.7–11.0%
+    view_1group_theory DOUBLE PRECISION NOT NULL DEFAULT 0  -- Часы: 1 → 20.6–25.7%
+);

--- a/models/channel_post_theory.go
+++ b/models/channel_post_theory.go
@@ -1,0 +1,13 @@
+package models
+
+// ChannelPostTheory хранит теоретическое распределение просмотров поста по группам часов.
+// channel_post_id связывает запись с конкретным постом из таблицы channel_post,
+// view_*_theory отражают ожидаемое число просмотров в соответствующий промежуток времени.
+type ChannelPostTheory struct {
+	ID               int     `json:"id"`
+	ChannelPostID    int     `json:"channel_post_id"`
+	View4GroupTheory float64 `json:"view_4group_theory"`
+	View3GroupTheory float64 `json:"view_3group_theory"`
+	View2GroupTheory float64 `json:"view_2group_theory"`
+	View1GroupTheory float64 `json:"view_1group_theory"`
+}

--- a/pkg/storage/channel_post_theory.go
+++ b/pkg/storage/channel_post_theory.go
@@ -1,0 +1,29 @@
+package storage
+
+import (
+	"atg_go/models"
+	"log"
+)
+
+// CreateChannelPostTheory сохраняет прогноз распределения просмотров по группам часов.
+// Используется для фиксации ожидаемых просмотров после публикации поста.
+func (db *DB) CreateChannelPostTheory(t models.ChannelPostTheory) error {
+	_, err := db.Conn.Exec(`
+                INSERT INTO channel_post_theory (
+                        channel_post_id,
+                        view_4group_theory,
+                        view_3group_theory,
+                        view_2group_theory,
+                        view_1group_theory
+                ) VALUES ($1, $2, $3, $4, $5)`,
+		t.ChannelPostID,
+		t.View4GroupTheory,
+		t.View3GroupTheory,
+		t.View2GroupTheory,
+		t.View1GroupTheory,
+	)
+	if err != nil {
+		log.Printf("[DB ERROR] сохранение теории просмотров: %v", err)
+	}
+	return err
+}


### PR DESCRIPTION
## Summary
- add channel_post_theory table to store theoretical view distribution
- provide Go model and storage method for channel_post_theory

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ad59f9ec3c8327b50a2199fc997aaa