### PR TITLE
Распределение просмотров поста по теории

### DIFF
--- a/pkg/storage/channel_post.go
+++ b/pkg/storage/channel_post.go
@@ -5,13 +5,15 @@ import (
 	"log"
 )
 
-// CreateChannelPost сохраняет информацию о новом посте канала в БД.
+// CreateChannelPost сохраняет информацию о новом посте канала в БД и возвращает идентификатор записи.
 // Используется мониторингом для фиксации публикаций заказов с расчётом активной аудитории.
-func (db *DB) CreateChannelPost(p models.ChannelPost) error {
-	_, err := db.Conn.Exec(`INSERT INTO channel_post (order_id, post_date_time, post_url, subs_active_view, subs_active_reaction, subs_active_repost) VALUES ($1, $2, $3, $4, $5, $6)`,
-		p.OrderID, p.PostDateTime, p.PostURL, p.SubsActiveView, p.SubsActiveReaction, p.SubsActiveRepost)
+func (db *DB) CreateChannelPost(p models.ChannelPost) (int, error) {
+	var id int
+	err := db.Conn.QueryRow(`INSERT INTO channel_post (order_id, post_date_time, post_url, subs_active_view, subs_active_reaction, subs_active_repost) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
+		p.OrderID, p.PostDateTime, p.PostURL, p.SubsActiveView, p.SubsActiveReaction, p.SubsActiveRepost).Scan(&id)
 	if err != nil {
 		log.Printf("[DB ERROR] сохранение поста: %v", err)
+		return 0, err
 	}
-	return err
+	return id, nil
 }

--- a/pkg/telegram/module/monitoring/monitoring.go
+++ b/pkg/telegram/module/monitoring/monitoring.go
@@ -113,8 +113,22 @@ func run(db *storage.DB) error {
 				SubsActiveReaction: &reaction,
 				SubsActiveRepost:   &repost,
 			}
-			if err := db.CreateChannelPost(cp); err != nil {
+			// Сохраняем пост и получаем его идентификатор для последующей теории
+			postID, err := db.CreateChannelPost(cp)
+			if err != nil {
 				log.Printf("[MONITORING] сохранение поста: %v", err)
+			} else {
+				// Формируем прогноз просмотров по группам часов
+				theory := models.ChannelPostTheory{
+					ChannelPostID:    postID,
+					View1GroupTheory: float64(randomByPercent(view, 20.6, 25.7)),
+					View2GroupTheory: float64(randomByPercent(view, 3.7, 6.3)),
+					View3GroupTheory: float64(randomByPercent(view, 6.7, 11.0)),
+					View4GroupTheory: float64(randomByPercent(view, 20.6, 25.7)),
+				}
+				if err := db.CreateChannelPostTheory(theory); err != nil {
+					log.Printf("[MONITORING] сохранение теории просмотров: %v", err)
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
## Summary
- сохраняем в channel_post идентификатор нового поста
- рассчитываем теоретическое распределение просмотров по группам часов и сохраняем в channel_post_theory

## Testing
- `go test ./pkg/storage`
- `go test ./pkg/telegram/module/monitoring` *(прервано: зависает в среде)*

------
https://chatgpt.com/codex/tasks/task_e_68ad64e61df483279a098b3cf1e5caf8