### PR TITLE
Реализована подписка аккаунтов на каналы заказов

### DIFF
--- a/internal/module/order_link_update.go
+++ b/internal/module/order_link_update.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"atg_go/internal/httputil"
+	subactive "atg_go/internal/subs_active"
 	telegrammodule "atg_go/pkg/telegram/module"
 
 	"github.com/gin-gonic/gin"
@@ -20,5 +21,10 @@ func (h *Handler) OrderLinkUpdate(c *gin.Context) {
 		httputil.RespondError(c, http.StatusInternalServerError, err.Error())
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"status": "links updated"})
+	if err := subactive.ActivateSubscriptions(h.DB); err != nil {
+		log.Printf("[HANDLER ERROR] активные подписки: %v", err)
+		httputil.RespondError(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "links updated and subs active"})
 }

--- a/internal/subs_active/subs_active.go
+++ b/internal/subs_active/subs_active.go
@@ -1,0 +1,51 @@
+package subs_active
+
+import (
+	"log"
+	"math/rand"
+	"time"
+
+	"atg_go/pkg/storage"
+	telegramsubs "atg_go/pkg/telegram/subs_active"
+)
+
+// rnd нужен для пауз между подписками.
+var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// ActivateSubscriptions проверяет заказы и подписывает недостающие аккаунты на их каналы.
+func ActivateSubscriptions(db *storage.DB) error {
+	orders, err := db.GetOrdersForMonitoring()
+	if err != nil {
+		return err
+	}
+	for _, o := range orders {
+		if o.SubsActiveCount == nil || *o.SubsActiveCount <= 0 || o.URLDefault == "" {
+			continue
+		}
+		current, err := db.CountOrderSubs(o.ID)
+		if err != nil {
+			log.Printf("[SUBS_ACTIVE] не удалось получить количество подписок для заказа %d: %v", o.ID, err)
+			continue
+		}
+		need := *o.SubsActiveCount - current
+		if need <= 0 {
+			continue
+		}
+		accounts, err := db.GetRandomAccountsForOrder(o.ID, need)
+		if err != nil {
+			log.Printf("[SUBS_ACTIVE] не удалось выбрать аккаунты для заказа %d: %v", o.ID, err)
+			continue
+		}
+		for _, acc := range accounts {
+			if err := telegramsubs.SubscribeAccount(db, acc, o.URLDefault); err != nil {
+				log.Printf("[SUBS_ACTIVE] аккаунт %d не смог подписаться на заказ %d: %v", acc.ID, o.ID, err)
+				continue
+			}
+			if err := db.AddOrderAccountSub(o.ID, acc.ID); err != nil {
+				log.Printf("[SUBS_ACTIVE] не удалось записать подписку аккаунта %d на заказ %d: %v", acc.ID, o.ID, err)
+			}
+			time.Sleep(time.Duration(rnd.Intn(3)+2) * time.Second)
+		}
+	}
+	return nil
+}

--- a/pkg/storage/order_account_subs.go
+++ b/pkg/storage/order_account_subs.go
@@ -1,0 +1,25 @@
+package storage
+
+import "atg_go/models"
+
+// CountOrderSubs возвращает количество подписок аккаунтов на конкретный заказ.
+func (db *DB) CountOrderSubs(orderID int) (int, error) {
+	var count int
+	err := db.Conn.QueryRow(`SELECT COUNT(*) FROM order_account_subs WHERE order_id = $1`, orderID).Scan(&count)
+	return count, err
+}
+
+// AddOrderAccountSub сохраняет факт подписки аккаунта на канал заказа.
+func (db *DB) AddOrderAccountSub(orderID, accountID int) error {
+	_, err := db.Conn.Exec(`INSERT INTO order_account_subs (order_id, account_id) VALUES ($1, $2)`, orderID, accountID)
+	return err
+}
+
+// GetRandomAccountsForOrder выбирает случайные авторизованные аккаунты,
+// которые ещё не подписаны на канал указанного заказа и не помечены как мониторинговые.
+func (db *DB) GetRandomAccountsForOrder(orderID, limit int) ([]models.Account, error) {
+	condition := `a.is_authorized = true AND a.account_monitoring = false AND NOT EXISTS (
+        SELECT 1 FROM order_account_subs oas WHERE oas.account_id = a.id AND oas.order_id = $1
+    ) ORDER BY RANDOM() LIMIT $2`
+	return db.getAccounts(condition, orderID, limit)
+}

--- a/pkg/telegram/subs_active/subs_active.go
+++ b/pkg/telegram/subs_active/subs_active.go
@@ -1,0 +1,54 @@
+// Package subs_active отвечает за подписку аккаунтов на каналы заказов.
+package subs_active
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"atg_go/models"
+	"atg_go/pkg/storage"
+	module "atg_go/pkg/telegram/module"
+	accountmutex "atg_go/pkg/telegram/module/account_mutex"
+
+	"github.com/gotd/td/tg"
+)
+
+// SubscribeAccount подписывает аккаунт на канал заказа по ссылке.
+func SubscribeAccount(db *storage.DB, acc models.Account, url string) error {
+	// Блокируем аккаунт, чтобы исключить параллельное использование
+	if err := accountmutex.LockAccount(acc.ID); err != nil {
+		return err
+	}
+	defer accountmutex.UnlockAccount(acc.ID)
+
+	client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, nil)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	return client.Run(ctx, func(ctx context.Context) error {
+		api := tg.NewClient(client)
+		username, err := module.Modf_ExtractUsername(url)
+		if err != nil {
+			return err
+		}
+		resolved, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: username})
+		if err != nil {
+			return err
+		}
+		channel, err := module.Modf_FindChannel(resolved.GetChats())
+		if err != nil {
+			return err
+		}
+		if err := module.Modf_JoinChannel(ctx, api, channel, db, acc.ID); err != nil {
+			if !strings.Contains(err.Error(), "USER_ALREADY_PARTICIPANT") {
+				return err
+			}
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
## Summary
- активная подписка: система проверяет заказы и подписывает недостающих исполнителей
- добавлены функции БД для фиксации подписок и выборки случайных аккаунтов
- обработчик `/module/order/link_updat` теперь запускает обновление ссылок и активные подписки

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ae2ab3c34c8327a1c7fd46d5c94a29