### PR TITLE
feat(models): add account and order subscription models

### DIFF
--- a/models/account_session.go
+++ b/models/account_session.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+// AccountSession хранит сериализованную сессию Telegram для аккаунта.
+type AccountSession struct {
+	ID       int       `json:"id"`        // Уникальный идентификатор записи
+	DateTime time.Time `json:"date_time"` // Время сохранения сессии
+	Account  int       `json:"account"`   // ID аккаунта, которому принадлежит сессия
+	DataJSON string    `json:"data_json"` // Содержимое сессии в формате JSON
+}

--- a/models/channel_post_fact.go
+++ b/models/channel_post_fact.go
@@ -1,0 +1,13 @@
+package models
+
+// ChannelPostFact фиксирует фактические просмотры поста по группам часов.
+// channel_post_theory_id связывает запись с прогнозом просмотров,
+// view_*_fact отражают реальные значения в указанные промежутки времени.
+type ChannelPostFact struct {
+	ID                  int     `json:"id"`
+	ChannelPostTheoryID int     `json:"channel_post_theory_id"`
+	View4GroupFact      float64 `json:"view_4group_fact"` // Часы: 7–24 → 0.5–3.2%
+	View3GroupFact      float64 `json:"view_3group_fact"` // Часы: 4–6 → 3.7–6.3%
+	View2GroupFact      float64 `json:"view_2group_fact"` // Часы: 2–3 → 6.7–11.0%
+	View1GroupFact      float64 `json:"view_1group_fact"` // Часы: 1 → 20.6–25.7%
+}

--- a/models/order_account_sub.go
+++ b/models/order_account_sub.go
@@ -1,0 +1,8 @@
+package models
+
+// OrderAccountSub связывает аккаунт с заказом, на канал которого он подписан.
+type OrderAccountSub struct {
+	ID        int `json:"id"`         // Уникальный идентификатор записи
+	OrderID   int `json:"order_id"`   // ID заказа, на канал которого подписался аккаунт
+	AccountID int `json:"account_id"` // ID аккаунта, подписанного на канал
+}


### PR DESCRIPTION
## Summary
- add AccountSession model for account_session table
- add OrderAccountSub model for order_account_subs table

## Testing
- `go test ./models`
- `go test ./...` (hang, aborted)


------
https://chatgpt.com/codex/tasks/task_e_68af0cfc6d588327b0caa5976dba1ccb