### PR TITLE
Автосоздание фактических просмотров при добавлении теории

### DIFF
--- a/migrations/2025-08-27-1000_add_cascade_channel_post_relations.sql
+++ b/migrations/2025-08-27-1000_add_cascade_channel_post_relations.sql
@@ -1,0 +1,12 @@
+-- Каскадное удаление теории и факта при удалении поста
+ALTER TABLE channel_post_theory
+    DROP CONSTRAINT IF EXISTS channel_post_theory_channel_post_id_fkey;
+ALTER TABLE channel_post_theory
+    ADD CONSTRAINT channel_post_theory_channel_post_id_fkey
+        FOREIGN KEY (channel_post_id) REFERENCES channel_post(id) ON DELETE CASCADE;
+
+ALTER TABLE channel_post_fact
+    DROP CONSTRAINT IF EXISTS channel_post_fact_channel_post_theory_id_fkey;
+ALTER TABLE channel_post_fact
+    ADD CONSTRAINT channel_post_fact_channel_post_theory_id_fkey
+        FOREIGN KEY (channel_post_theory_id) REFERENCES channel_post_theory(id) ON DELETE CASCADE;

--- a/pkg/storage/channel_post_fact.go
+++ b/pkg/storage/channel_post_fact.go
@@ -1,0 +1,20 @@
+package storage
+
+import (
+	"atg_go/models"
+	"log"
+)
+
+// CreateChannelPostFact создаёт запись фактических просмотров с нулевыми значениями.
+func (db *DB) CreateChannelPostFact(f models.ChannelPostFact) error {
+	_, err := db.Conn.Exec(`
+                INSERT INTO channel_post_fact (
+                        channel_post_theory_id
+                ) VALUES ($1)`,
+		f.ChannelPostTheoryID,
+	)
+	if err != nil {
+		log.Printf("[DB ERROR] сохранение фактических просмотров: %v", err)
+	}
+	return err
+}

--- a/pkg/storage/channel_post_theory.go
+++ b/pkg/storage/channel_post_theory.go
@@ -5,25 +5,26 @@ import (
 	"log"
 )
 
-// CreateChannelPostTheory сохраняет прогноз распределения просмотров по группам часов.
-// Используется для фиксации ожидаемых просмотров после публикации поста.
-func (db *DB) CreateChannelPostTheory(t models.ChannelPostTheory) error {
-	_, err := db.Conn.Exec(`
+// CreateChannelPostTheory сохраняет прогноз распределения просмотров по группам часов
+// и возвращает идентификатор созданной записи.
+func (db *DB) CreateChannelPostTheory(t models.ChannelPostTheory) (int, error) {
+	var id int
+	err := db.Conn.QueryRow(`
                 INSERT INTO channel_post_theory (
                         channel_post_id,
-                       view_7_24hour_theory,
-                       view_4_6hour_theory,
-                       view_2_3hour_theory,
-                       view_1hour_theory
-                ) VALUES ($1, $2, $3, $4, $5)`,
+                        view_7_24hour_theory,
+                        view_4_6hour_theory,
+                        view_2_3hour_theory,
+                        view_1hour_theory
+                ) VALUES ($1, $2, $3, $4, $5) RETURNING id`,
 		t.ChannelPostID,
 		t.View724HourTheory,
 		t.View46HourTheory,
 		t.View23HourTheory,
 		t.View1HourTheory,
-	)
+	).Scan(&id)
 	if err != nil {
 		log.Printf("[DB ERROR] сохранение теории просмотров: %v", err)
 	}
-	return err
+	return id, err
 }

--- a/pkg/telegram/module/monitoring/monitoring.go
+++ b/pkg/telegram/module/monitoring/monitoring.go
@@ -126,8 +126,16 @@ func run(db *storage.DB) error {
 					View46HourTheory:  float64(randomByPercent(view, 3.7, 6.3)),
 					View724HourTheory: float64(randomByPercent(view, 0.5, 3.2)),
 				}
-				if err := db.CreateChannelPostTheory(theory); err != nil {
+				// Создаём прогноз и получаем его идентификатор
+				theoryID, err := db.CreateChannelPostTheory(theory)
+				if err != nil {
 					log.Printf("[MONITORING] сохранение теории просмотров: %v", err)
+				} else {
+					// Создаём запись фактических просмотров с нулевыми значениями
+					fact := models.ChannelPostFact{ChannelPostTheoryID: theoryID}
+					if err := db.CreateChannelPostFact(fact); err != nil {
+						log.Printf("[MONITORING] сохранение факта просмотров: %v", err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- добавить создание записи `channel_post_fact` сразу после сохранения `channel_post_theory`
- реализовать методы БД для сохранения теории и факта просмотров
- каскадно удалять теорию и фактические просмотры при удалении поста

## Testing
- `go test ./pkg/storage`
- `go test ./pkg/telegram/reaction` *(повисло без вывода)*

------
https://chatgpt.com/codex/tasks/task_e_68af6ffb44d483278e6a98fc5c25e413