### PR TITLE
Планировщик просмотров постов в monitoring

### DIFF
--- a/pkg/storage/channel_post_fact.go
+++ b/pkg/storage/channel_post_fact.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"fmt"
+
 	"atg_go/models"
 	"log"
 )
@@ -17,4 +19,15 @@ func (db *DB) CreateChannelPostFact(f models.ChannelPostFact) error {
 		log.Printf("[DB ERROR] сохранение фактических просмотров: %v", err)
 	}
 	return err
+}
+
+// IncrementChannelPostFact увеличивает счётчик просмотров в заданном столбце на единицу.
+// column ожидает одно из имён полей вида view_1hour_fact, view_2_3hour_fact и т.д.
+func (db *DB) IncrementChannelPostFact(theoryID int, column string) error {
+	query := fmt.Sprintf("UPDATE channel_post_fact SET %s = %s + 1 WHERE channel_post_theory_id = $1", column, column)
+	if _, err := db.Conn.Exec(query, theoryID); err != nil {
+		log.Printf("[DB ERROR] обновление фактических просмотров: %v", err)
+		return err
+	}
+	return nil
 }

--- a/pkg/telegram/module/monitoring/monitoring.go
+++ b/pkg/telegram/module/monitoring/monitoring.go
@@ -135,6 +135,9 @@ func run(db *storage.DB) error {
 					fact := models.ChannelPostFact{ChannelPostTheoryID: theoryID}
 					if err := db.CreateChannelPostFact(fact); err != nil {
 						log.Printf("[MONITORING] сохранение факта просмотров: %v", err)
+					} else {
+						// Планируем просмотры поста по интервалам
+						schedulePostViews(db, cp, theory, theoryID)
 					}
 				}
 			}

--- a/pkg/telegram/module/monitoring/view_scheduler.go
+++ b/pkg/telegram/module/monitoring/view_scheduler.go
@@ -1,0 +1,61 @@
+package monitoring
+
+import (
+	"log"
+	"math/rand"
+	"time"
+
+	"atg_go/models"
+	"atg_go/pkg/storage"
+	view "atg_go/pkg/telegram/view"
+)
+
+// schedulePostViews равномерно распределяет просмотры поста по временным промежуткам.
+// Для каждого интервала создаётся фоновая задача, которая вызывает просмотр поста
+// выбранным аккаунтом и увеличивает соответствующее поле факта.
+func schedulePostViews(db *storage.DB, post models.ChannelPost, theory models.ChannelPostTheory, theoryID int) {
+	accounts, err := db.GetAuthorizedAccounts()
+	if err != nil || len(accounts) == 0 {
+		log.Printf("[MONITORING] не удалось получить аккаунты для просмотров: %v", err)
+		return
+	}
+
+	type period struct {
+		count  int
+		start  time.Duration
+		end    time.Duration
+		column string
+	}
+
+	periods := []period{
+		{int(theory.View1HourTheory), 0, time.Hour, "view_1hour_fact"},
+		{int(theory.View23HourTheory), 2 * time.Hour, 3 * time.Hour, "view_2_3hour_fact"},
+		{int(theory.View46HourTheory), 4 * time.Hour, 6 * time.Hour, "view_4_6hour_fact"},
+		{int(theory.View724HourTheory), 7 * time.Hour, 24 * time.Hour, "view_7_24hour_fact"},
+	}
+
+	for _, p := range periods {
+		if p.count <= 0 {
+			continue
+		}
+		step := (p.end - p.start) / time.Duration(p.count)
+		for i := 0; i < p.count; i++ {
+			acc := accounts[rand.Intn(len(accounts))]
+			delay := post.PostDateTime.Add(p.start + step*time.Duration(i)).Sub(time.Now())
+			if delay < 0 {
+				delay = 0
+			}
+			go func(a models.Account, column string, d time.Duration) {
+				time.AfterFunc(d, func() {
+					if err := view.ViewPost(db, a, post.PostURL); err != nil {
+						log.Printf("[MONITORING] просмотр поста не выполнен: %v", err)
+						return
+					}
+					if err := db.IncrementChannelPostFact(theoryID, column); err != nil {
+						log.Printf("[MONITORING] обновление факта просмотров: %v", err)
+					}
+				})
+			}(acc, p.column, delay)
+		}
+	}
+}

--- a/pkg/telegram/view/view.go
+++ b/pkg/telegram/view/view.go
@@ -1,0 +1,61 @@
+package view
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"atg_go/models"
+	"atg_go/pkg/storage"
+	module "atg_go/pkg/telegram/module"
+	accountmutex "atg_go/pkg/telegram/module/account_mutex"
+
+	"github.com/gotd/td/tg"
+)
+
+// ViewPost открывает пост канала, чтобы увеличить счётчик просмотров.
+func ViewPost(db *storage.DB, acc models.Account, postURL string) error {
+	if err := accountmutex.LockAccount(acc.ID); err != nil {
+		return err
+	}
+	defer accountmutex.UnlockAccount(acc.ID)
+
+	client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, nil)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	return client.Run(ctx, func(ctx context.Context) error {
+		api := tg.NewClient(client)
+		trimmed := strings.TrimPrefix(postURL, "https://t.me/")
+		parts := strings.Split(trimmed, "/")
+		if len(parts) != 2 {
+			return fmt.Errorf("некорректная ссылка на пост")
+		}
+		username := parts[0]
+		msgID, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return err
+		}
+		resolved, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: username})
+		if err != nil {
+			return err
+		}
+		ch, err := module.Modf_FindChannel(resolved.GetChats())
+		if err != nil {
+			return err
+		}
+		// Запрашиваем просмотр сообщения с флагом Increment=true
+		_, err = api.MessagesGetMessagesViews(ctx, &tg.MessagesGetMessagesViewsRequest{
+			Peer:      &tg.InputPeerChannel{ChannelID: ch.ID, AccessHash: ch.AccessHash},
+			ID:        []int{msgID},
+			Increment: true,
+		})
+		return err
+	})
+}


### PR DESCRIPTION
## Summary
- запланированы просмотры постов авторизованными аккаунтами
- добавлено обновление фактических просмотров по интервалам

## Testing
- `go test ./...` *(failed: зависание команды)*

------
https://chatgpt.com/codex/tasks/task_e_68af7f8c550c8327984b90c138b50b88