### PR TITLE
Логирование просмотров постов в Activity

### DIFF
--- a/pkg/storage/activity.go
+++ b/pkg/storage/activity.go
@@ -17,6 +17,9 @@ const ActivityTypeReaction = "reaction"
 // ActivityTypeComment — значение поля activity_type для комментариев.
 const ActivityTypeComment = "comment"
 
+// ActivityTypeSubsActiveView — значение поля activity_type для просмотров поста.
+const ActivityTypeSubsActiveView = "subs_active_view"
+
 // SaveActivity сохраняет действие аккаунта в таблице activity вместе со временем.
 // messageID — идентификатор сообщения: для ActivityTypeReaction это ID сообщения
 // из чата обсуждения, для ActivityTypeComment — ID поста канала.
@@ -45,6 +48,12 @@ func (db *DB) SaveReaction(accountID, channelID, messageID int) error {
 // а не идентификатор сообщения из обсуждения.
 func (db *DB) SaveComment(accountID, channelID, messageID int) error {
 	return db.SaveActivity(accountID, channelID, messageID, ActivityTypeComment)
+}
+
+// SaveSubsActiveView сохраняет информацию о просмотре поста активной аудиторией.
+// messageID должен быть ID поста, который был открыт для увеличения счётчика просмотров.
+func (db *DB) SaveSubsActiveView(accountID, channelID, messageID int) error {
+	return db.SaveActivity(accountID, channelID, messageID, ActivityTypeSubsActiveView)
 }
 
 // HasCommentForPost проверяет, существует ли комментарий для поста с указанным

--- a/pkg/telegram/module/save_activity.go
+++ b/pkg/telegram/module/save_activity.go
@@ -18,3 +18,9 @@ func SaveReactionActivity(db *storage.DB, accountID, channelID, messageID int) e
 func SaveCommentActivity(db *storage.DB, accountID, channelID, messageID int) error {
 	return db.SaveComment(accountID, channelID, messageID)
 }
+
+// SaveViewActivity фиксирует просмотр поста активной аудиторией.
+// messageID — идентификатор поста канала, открытого для увеличения просмотров.
+func SaveViewActivity(db *storage.DB, accountID, channelID, messageID int) error {
+	return db.SaveSubsActiveView(accountID, channelID, messageID)
+}

--- a/pkg/telegram/view/view.go
+++ b/pkg/telegram/view/view.go
@@ -56,6 +56,10 @@ func ViewPost(db *storage.DB, acc models.Account, postURL string) error {
 			ID:        []int{msgID},
 			Increment: true,
 		})
-		return err
+		if err != nil {
+			return err
+		}
+		// Сохраняем факт просмотра в таблице активности
+		return module.SaveViewActivity(db, acc.ID, int(ch.ID), msgID)
 	})
 }


### PR DESCRIPTION
## Summary
- фиксируем просмотры постов в таблице активности
- добавлен новый тип активности `subs_active_view` и соответствующие функции

## Testing
- `go test ./pkg/storage`

------
https://chatgpt.com/codex/tasks/task_e_68af8786e4b48327a130ed6a46b67c64