### PR TITLE
Добавлены метрики реакций и репостов за первые 24 часа

### DIFF
--- a/migrations/2025-08-27-1210_add_reaction_repost_24h_to_channel_post.sql
+++ b/migrations/2025-08-27-1210_add_reaction_repost_24h_to_channel_post.sql
@@ -1,0 +1,8 @@
+-- Добавление столбцов реакций и репостов за первые 24 часа
+ALTER TABLE channel_post_theory
+    ADD COLUMN reaction_24hour_theory INTEGER NOT NULL DEFAULT 0, -- Реакции за первые 24 часа
+    ADD COLUMN repost_24hour_theory INTEGER NOT NULL DEFAULT 0;   -- Репосты за первые 24 часа
+
+ALTER TABLE channel_post_fact
+    ADD COLUMN reaction_24hour_fact INTEGER NOT NULL DEFAULT 0, -- Реакции за первые 24 часа
+    ADD COLUMN repost_24hour_fact INTEGER NOT NULL DEFAULT 0;  -- Репосты за первые 24 часа

--- a/models/channel_post_fact.go
+++ b/models/channel_post_fact.go
@@ -6,8 +6,10 @@ package models
 type ChannelPostFact struct {
 	ID                  int     `json:"id"`
 	ChannelPostTheoryID int     `json:"channel_post_theory_id"`
-	View724HourFact     float64 `json:"view_7_24hour_fact"` // Часы: 7–24 → 0.5–3.2%
-	View46HourFact      float64 `json:"view_4_6hour_fact"`  // Часы: 4–6 → 3.7–6.3%
-	View23HourFact      float64 `json:"view_2_3hour_fact"`  // Часы: 2–3 → 6.7–11.0%
-	View1HourFact       float64 `json:"view_1hour_fact"`    // Часы: 1 → 20.6–25.7%
+	View724HourFact     float64 `json:"view_7_24hour_fact"`   // Часы: 7–24 → 0.5–3.2%
+	View46HourFact      float64 `json:"view_4_6hour_fact"`    // Часы: 4–6 → 3.7–6.3%
+	View23HourFact      float64 `json:"view_2_3hour_fact"`    // Часы: 2–3 → 6.7–11.0%
+	View1HourFact       float64 `json:"view_1hour_fact"`      // Часы: 1 → 20.6–25.7%
+	Reaction24HourFact  int     `json:"reaction_24hour_fact"` // Реакции за первые 24 часа
+	Repost24HourFact    int     `json:"repost_24hour_fact"`   // Репосты за первые 24 часа
 }

--- a/models/channel_post_theory.go
+++ b/models/channel_post_theory.go
@@ -4,10 +4,12 @@ package models
 // channel_post_id связывает запись с конкретным постом из таблицы channel_post,
 // view_*_theory отражают ожидаемое число просмотров в соответствующий промежуток времени.
 type ChannelPostTheory struct {
-	ID                int     `json:"id"`
-	ChannelPostID     int     `json:"channel_post_id"`
-	View724HourTheory float64 `json:"view_7_24hour_theory"` // Часы: 7–24 → 0.5–3.2%
-	View46HourTheory  float64 `json:"view_4_6hour_theory"`  // Часы: 4–6 → 3.7–6.3%
-	View23HourTheory  float64 `json:"view_2_3hour_theory"`  // Часы: 2–3 → 6.7–11.0%
-	View1HourTheory   float64 `json:"view_1hour_theory"`    // Часы: 1 → 20.6–25.7%
+	ID                   int     `json:"id"`
+	ChannelPostID        int     `json:"channel_post_id"`
+	View724HourTheory    float64 `json:"view_7_24hour_theory"`   // Часы: 7–24 → 0.5–3.2%
+	View46HourTheory     float64 `json:"view_4_6hour_theory"`    // Часы: 4–6 → 3.7–6.3%
+	View23HourTheory     float64 `json:"view_2_3hour_theory"`    // Часы: 2–3 → 6.7–11.0%
+	View1HourTheory      float64 `json:"view_1hour_theory"`      // Часы: 1 → 20.6–25.7%
+	Reaction24HourTheory int     `json:"reaction_24hour_theory"` // Реакции за первые 24 часа
+	Repost24HourTheory   int     `json:"repost_24hour_theory"`   // Репосты за первые 24 часа
 }

--- a/pkg/storage/channel_post_fact.go
+++ b/pkg/storage/channel_post_fact.go
@@ -10,10 +10,14 @@ import (
 // CreateChannelPostFact создаёт запись фактических просмотров с нулевыми значениями.
 func (db *DB) CreateChannelPostFact(f models.ChannelPostFact) error {
 	_, err := db.Conn.Exec(`
-                INSERT INTO channel_post_fact (
-                        channel_post_theory_id
-                ) VALUES ($1)`,
+               INSERT INTO channel_post_fact (
+                       channel_post_theory_id,
+                       reaction_24hour_fact,
+                       repost_24hour_fact
+               ) VALUES ($1, $2, $3)`,
 		f.ChannelPostTheoryID,
+		f.Reaction24HourFact,
+		f.Repost24HourFact,
 	)
 	if err != nil {
 		log.Printf("[DB ERROR] сохранение фактических просмотров: %v", err)

--- a/pkg/storage/channel_post_theory.go
+++ b/pkg/storage/channel_post_theory.go
@@ -15,13 +15,17 @@ func (db *DB) CreateChannelPostTheory(t models.ChannelPostTheory) (int, error) {
                         view_7_24hour_theory,
                         view_4_6hour_theory,
                         view_2_3hour_theory,
-                        view_1hour_theory
-                ) VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+                        view_1hour_theory,
+                        reaction_24hour_theory,
+                        repost_24hour_theory
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
 		t.ChannelPostID,
 		t.View724HourTheory,
 		t.View46HourTheory,
 		t.View23HourTheory,
 		t.View1HourTheory,
+		t.Reaction24HourTheory,
+		t.Repost24HourTheory,
 	).Scan(&id)
 	if err != nil {
 		log.Printf("[DB ERROR] сохранение теории просмотров: %v", err)

--- a/pkg/telegram/module/monitoring/monitoring.go
+++ b/pkg/telegram/module/monitoring/monitoring.go
@@ -120,11 +120,13 @@ func run(db *storage.DB) error {
 			} else {
 				// Формируем прогноз просмотров по группам часов
 				theory := models.ChannelPostTheory{
-					ChannelPostID:     postID,
-					View1HourTheory:   float64(randomByPercent(view, 20.6, 25.7)),
-					View23HourTheory:  float64(randomByPercent(view, 6.7, 11.0)),
-					View46HourTheory:  float64(randomByPercent(view, 3.7, 6.3)),
-					View724HourTheory: float64(randomByPercent(view, 0.5, 3.2)),
+					ChannelPostID:        postID,
+					View1HourTheory:      float64(randomByPercent(view, 20.6, 25.7)),
+					View23HourTheory:     float64(randomByPercent(view, 6.7, 11.0)),
+					View46HourTheory:     float64(randomByPercent(view, 3.7, 6.3)),
+					View724HourTheory:    float64(randomByPercent(view, 0.5, 3.2)),
+					Reaction24HourTheory: reaction,
+					Repost24HourTheory:   repost,
 				}
 				// Создаём прогноз и получаем его идентификатор
 				theoryID, err := db.CreateChannelPostTheory(theory)


### PR DESCRIPTION
## Summary
- расширены таблицы `channel_post_theory` и `channel_post_fact` новыми полями для реакций и репостов за первые сутки
- обновлены модели и слой хранения для работы с новыми полями
- мониторинг теперь сохраняет прогнозируемые реакции и репосты в теоретические данные

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b084970ea48327aaad42b821623f94