### PR TITLE
планирование реакций и репостов

### DIFF
--- a/pkg/telegram/post/reaction.go
+++ b/pkg/telegram/post/reaction.go
@@ -1,0 +1,87 @@
+package post
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
+	"time"
+
+	"atg_go/models"
+	"atg_go/pkg/storage"
+	module "atg_go/pkg/telegram/module"
+	accountmutex "atg_go/pkg/telegram/module/account_mutex"
+
+	"github.com/gotd/td/tg"
+)
+
+// reactions содержит список базовых реакций, которые пытаемся использовать.
+var reactions = []string{"❤️", "👍"}
+
+// SendReaction добавляет реакцию к посту канала по ссылке postURL.
+// Функция не фиксирует активность аккаунта.
+func SendReaction(db *storage.DB, acc models.Account, postURL string) error {
+	// Блокируем аккаунт на время операции, чтобы избежать параллельного использования
+	if err := accountmutex.LockAccount(acc.ID); err != nil {
+		return err
+	}
+	defer accountmutex.UnlockAccount(acc.ID)
+
+	// Инициализируем клиента Telegram для указанного аккаунта
+	client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, nil)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	return client.Run(ctx, func(ctx context.Context) error {
+		api := tg.NewClient(client)
+
+		// Извлекаем username канала и ID сообщения из ссылки вида https://t.me/name/id
+		trimmed := strings.TrimPrefix(postURL, "https://t.me/")
+		parts := strings.Split(trimmed, "/")
+		if len(parts) != 2 {
+			return fmt.Errorf("некорректная ссылка на пост")
+		}
+		username := parts[0]
+		msgID, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return err
+		}
+
+		// Получаем информацию о канале по username
+		resolved, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: username})
+		if err != nil {
+			return err
+		}
+		ch, err := module.Modf_FindChannel(resolved.GetChats())
+		if err != nil {
+			return err
+		}
+
+		// Пытаемся подписаться на канал; игнорируем ошибку, если уже участник
+		_ = module.Modf_JoinChannel(ctx, api, ch, db, acc.ID)
+
+		// Получаем разрешённые реакции для канала
+		allowed, err := module.GetAllowedReactions(ctx, api, ch, reactions)
+		if err != nil {
+			return err
+		}
+		if len(allowed) == 0 {
+			return fmt.Errorf("нет доступных реакций")
+		}
+
+		// Выбираем случайную реакцию из разрешённых и отправляем её
+		reaction := allowed[rand.Intn(len(allowed))]
+		_, err = api.MessagesSendReaction(ctx, &tg.MessagesSendReactionRequest{
+			Peer:        &tg.InputPeerChannel{ChannelID: ch.ID, AccessHash: ch.AccessHash},
+			MsgID:       msgID,
+			Reaction:    []tg.ReactionClass{&tg.ReactionEmoji{Emoticon: reaction}},
+			AddToRecent: true,
+		})
+		return err
+	})
+}

--- a/pkg/telegram/post/repost.go
+++ b/pkg/telegram/post/repost.go
@@ -1,0 +1,74 @@
+package post
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
+	"time"
+
+	"atg_go/models"
+	"atg_go/pkg/storage"
+	module "atg_go/pkg/telegram/module"
+	accountmutex "atg_go/pkg/telegram/module/account_mutex"
+
+	"github.com/gotd/td/tg"
+)
+
+// SendRepost пересылает пост канала в "Избранное" аккаунта.
+// Функция не фиксирует активность.
+func SendRepost(db *storage.DB, acc models.Account, postURL string) error {
+	// Защищаем аккаунт от параллельного использования
+	if err := accountmutex.LockAccount(acc.ID); err != nil {
+		return err
+	}
+	defer accountmutex.UnlockAccount(acc.ID)
+
+	// Создаём клиента Telegram
+	client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, nil)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	return client.Run(ctx, func(ctx context.Context) error {
+		api := tg.NewClient(client)
+
+		// Парсим ссылку поста
+		trimmed := strings.TrimPrefix(postURL, "https://t.me/")
+		parts := strings.Split(trimmed, "/")
+		if len(parts) != 2 {
+			return fmt.Errorf("некорректная ссылка на пост")
+		}
+		username := parts[0]
+		msgID, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return err
+		}
+
+		// Разрешаем имя пользователя и находим канал
+		resolved, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: username})
+		if err != nil {
+			return err
+		}
+		ch, err := module.Modf_FindChannel(resolved.GetChats())
+		if err != nil {
+			return err
+		}
+
+		// Подписываемся на канал при необходимости
+		_ = module.Modf_JoinChannel(ctx, api, ch, db, acc.ID)
+
+		// Пересылаем сообщение в личный чат (Избранное)
+		_, err = api.MessagesForwardMessages(ctx, &tg.MessagesForwardMessagesRequest{
+			FromPeer: &tg.InputPeerChannel{ChannelID: ch.ID, AccessHash: ch.AccessHash},
+			ID:       []int{msgID},
+			ToPeer:   &tg.InputPeerSelf{},
+			RandomID: []int64{rand.Int63()},
+		})
+		return err
+	})
+}


### PR DESCRIPTION
## Summary
- добавлены функции отправки реакции и репоста по ссылке на пост без фиксации активности
- просмотры дополнили планированием реакций и репостов с учётом требуемого количества

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b09b54c344832793b662385557347c