### PR TITLE
feat: pick random channel when order has no categories

### DIFF
--- a/pkg/storage/comment_test.go
+++ b/pkg/storage/comment_test.go
@@ -1,0 +1,80 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"testing"
+)
+
+type commentTestDriver struct{}
+
+type commentTestConn struct{ step int }
+
+type commentTestRows struct {
+	columns []string
+	data    [][]driver.Value
+	idx     int
+}
+
+type commentDummyResult struct{}
+
+func (commentTestDriver) Open(name string) (driver.Conn, error) { return &commentTestConn{}, nil }
+
+func (c *commentTestConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *commentTestConn) Close() error              { return nil }
+func (c *commentTestConn) Begin() (driver.Tx, error) { return nil, errors.New("not implemented") }
+
+func (c *commentTestConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	switch c.step {
+	case 0:
+		c.step++
+		return &commentTestRows{columns: []string{"category"}, data: [][]driver.Value{{nil}}}, nil
+	case 1:
+		c.step++
+		return &commentTestRows{columns: []string{"id", "name", "urls"}, data: [][]driver.Value{{int64(1), "cat", []byte("[\"url\"]")}}}, nil
+	default:
+		return nil, errors.New("unexpected query")
+	}
+}
+
+func (c *commentTestConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	return commentDummyResult{}, nil
+}
+
+func (commentDummyResult) LastInsertId() (int64, error) { return 0, nil }
+func (commentDummyResult) RowsAffected() (int64, error) { return 0, nil }
+
+func (r *commentTestRows) Columns() []string { return r.columns }
+func (r *commentTestRows) Close() error      { return nil }
+func (r *commentTestRows) Next(dest []driver.Value) error {
+	if r.idx >= len(r.data) {
+		return io.EOF
+	}
+	copy(dest, r.data[r.idx])
+	r.idx++
+	return nil
+}
+
+func init() { sql.Register("commentDummy", commentTestDriver{}) }
+
+func TestPickRandomChannelWithoutCategories(t *testing.T) {
+	db, err := sql.Open("commentDummy", "")
+	if err != nil {
+		t.Fatalf("не удалось открыть мок БД: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	cdb := &CommentDB{Conn: db}
+	url, err := PickRandomChannel(cdb, 1)
+	if err != nil {
+		t.Fatalf("ожидался канал, получена ошибка: %v", err)
+	}
+	if url != "url" {
+		t.Fatalf("неверный URL канала: %s", url)
+	}
+}

--- a/pkg/storage/order_test.go
+++ b/pkg/storage/order_test.go
@@ -1,0 +1,129 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+
+	"atg_go/models"
+)
+
+// orderTestDriver реализует минимальный SQL-драйвер для теста CreateOrder.
+// Он возвращает предопределённые ответы и не требует внешних зависимостей.
+type orderTestDriver struct{}
+
+type orderTestConn struct{ step int }
+
+type orderTestTx struct{}
+
+type orderTestRows struct {
+	columns []string
+	data    [][]driver.Value
+	idx     int
+}
+
+type orderDummyResult struct{}
+
+func (orderTestDriver) Open(name string) (driver.Conn, error) { return &orderTestConn{}, nil }
+
+func (c *orderTestConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *orderTestConn) Close() error              { return nil }
+func (c *orderTestConn) Begin() (driver.Tx, error) { return &orderTestTx{}, nil }
+
+func (c *orderTestConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	switch c.step {
+	case 0:
+		// Выборка существующих категорий — возвращаем одну найденную
+		c.step++
+		return &orderTestRows{columns: []string{"name"}, data: [][]driver.Value{{"известная"}}}, nil
+	case 1:
+		// Вставка заказа — возвращаем созданную запись
+		c.step++
+		return &orderTestRows{
+			columns: []string{"id", "accounts_number_fact", "date_time", "subs_active_count"},
+			data:    [][]driver.Value{{int64(1), int64(0), time.Now(), nil}},
+		}, nil
+	case 2:
+		// Запрос аккаунтов — возвращаем пустой набор
+		c.step++
+		return &orderTestRows{columns: []string{"id"}, data: [][]driver.Value{}}, nil
+	default:
+		return nil, errors.New("unexpected query")
+	}
+}
+
+func (c *orderTestConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	// В тесте не выполняются запросы Exec, но метод должен существовать
+	return orderDummyResult{}, nil
+}
+
+func (orderTestTx) Commit() error   { return nil }
+func (orderTestTx) Rollback() error { return nil }
+
+func (r *orderTestRows) Columns() []string { return r.columns }
+func (r *orderTestRows) Close() error      { return nil }
+func (r *orderTestRows) Next(dest []driver.Value) error {
+	if r.idx >= len(r.data) {
+		return io.EOF
+	}
+	copy(dest, r.data[r.idx])
+	r.idx++
+	return nil
+}
+
+func (orderDummyResult) LastInsertId() (int64, error) { return 0, nil }
+func (orderDummyResult) RowsAffected() (int64, error) { return 1, nil }
+
+func init() {
+	sql.Register("orderDummy", orderTestDriver{})
+}
+
+// TestCreateOrderIgnoresUnknownCategories проверяет, что заказ создаётся даже при наличии
+// неизвестных категорий, которые логируются и не попадают в итоговый список.
+func TestCreateOrderIgnoresUnknownCategories(t *testing.T) {
+	db, err := sql.Open("orderDummy", "")
+	if err != nil {
+		t.Fatalf("не удалось открыть мок БД: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	storageDB := &DB{Conn: db}
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(os.Stderr)
+		log.SetFlags(log.LstdFlags)
+	}()
+
+	o := models.Order{
+		Name:                 "тест",
+		Category:             pq.StringArray{"известная", "неизвестная"},
+		URLDescription:       "desc",
+		URLDefault:           "https://t.me/c/123/abc",
+		AccountsNumberTheory: 0,
+		Gender:               pq.StringArray{"male"},
+	}
+	created, err := storageDB.CreateOrder(o)
+	if err != nil {
+		t.Fatalf("создание заказа завершилось ошибкой: %v", err)
+	}
+	if len(created.Category) != 1 || created.Category[0] != "известная" {
+		t.Fatalf("категории отфильтрованы неверно: %v", created.Category)
+	}
+	if !strings.Contains(buf.String(), "категория \"неизвестная\" не найдена") {
+		t.Fatalf("в логах отсутствует предупреждение о неизвестной категории: %s", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- allow channel selection without order categories
- cover random channel selection with test

## Testing
- `golangci-lint run` *(fails: Error return value of `dbConn.Close` is not checked, etc.)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0d4741a048327bc009867252426e3