### PR TITLE
Переименование таблицы channels в categories

### DIFF
--- a/internal/order/handler.go
+++ b/internal/order/handler.go
@@ -41,9 +41,9 @@ func (h *Handler) CreateOrder(c *gin.Context) {
 	c.JSON(200, created)
 }
 
-// GetCategories возвращает список доступных категорий из таблицы channels
+// GetCategories возвращает список доступных категорий из таблицы categories
 func (h *Handler) GetCategories(c *gin.Context) {
-	names, err := h.DB.GetChannelNames()
+	names, err := h.DB.GetCategoryNames()
 	if err != nil {
 		httputil.RespondError(c, 500, "db error")
 		return

--- a/migrations/2025-08-28-2240_rename_channels_to_categories.sql
+++ b/migrations/2025-08-28-2240_rename_channels_to_categories.sql
@@ -1,0 +1,2 @@
+-- Переименование таблицы channels в categories
+ALTER TABLE channels RENAME TO categories;

--- a/models/category.go
+++ b/models/category.go
@@ -1,7 +1,7 @@
 package models
 
-// Channel представляет группу каналов в БД
-type Channel struct {
+// Category представляет группу каналов в БД
+type Category struct {
 	ID   int      `json:"id"`
 	Name string   `json:"name"`
 	URLs []string `json:"urls"` // Массив URL вместо JSONB для удобства

--- a/models/order.go
+++ b/models/order.go
@@ -19,7 +19,7 @@ import (
 type Order struct {
 	ID                   int            `json:"id"`
 	Name                 string         `json:"name"`
-	Category             pq.StringArray `json:"category"`        // Перечень категорий из channels; может быть пустым
+	Category             pq.StringArray `json:"category"`        // Перечень категорий из таблицы categories; может быть пустым
 	URLDescription       string         `json:"url_description"` // Текст ссылки для описания
 	URLDefault           string         `json:"url_default"`     // Ссылка по умолчанию (уникальная)
 	ChannelTGID          *string        `json:"channel_tgid"`    // ID канала, извлечённый из URLDefault

--- a/pkg/storage/category.go
+++ b/pkg/storage/category.go
@@ -2,10 +2,10 @@ package storage
 
 import "database/sql"
 
-// GetChannelNames возвращает список названий всех каналов
+// GetCategoryNames возвращает список названий всех категорий
 // Используется для заполнения выпадающего списка категорий заказов
-func (db *DB) GetChannelNames() ([]string, error) {
-	rows, err := db.Conn.Query(`SELECT name FROM channels`)
+func (db *DB) GetCategoryNames() ([]string, error) {
+	rows, err := db.Conn.Query(`SELECT name FROM categories`)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/order.go
+++ b/pkg/storage/order.go
@@ -109,9 +109,9 @@ func (db *DB) CreateOrder(o models.Order) (*models.Order, error) {
 	defer tx.Rollback()
 
 	// Проверяем указанные категории и игнорируем неизвестные.
-	// Так заказ не привязывается к несуществующим каналам, но продолжает создаваться.
+	// Так заказ не привязывается к несуществующим категориям, но продолжает создаваться.
 	if len(o.Category) > 0 {
-		rows, err := tx.Query(`SELECT name FROM channels WHERE name = ANY($1)`, pq.Array(o.Category))
+		rows, err := tx.Query(`SELECT name FROM categories WHERE name = ANY($1)`, pq.Array(o.Category))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- переименована таблица `channels` в `categories`
- обновлены модели и запросы для работы с `categories`
- добавлена миграция

## Testing
- `go test ./...` *(зависло, окружение не позволило выполнить)*
- `go vet ./...` *(зависло, окружение не позволило выполнить)*

------
https://chatgpt.com/codex/tasks/task_e_68b0da934c508327a3f68869fc4812cc