### PR TITLE
sync order subs with accounts fact

### DIFF
--- a/internal/module/order_link_update.go
+++ b/internal/module/order_link_update.go
@@ -6,6 +6,7 @@ import (
 
 	"atg_go/internal/httputil"
 	subactive "atg_go/internal/subs_active"
+	subsfact "atg_go/internal/subs_fact"
 	telegrammodule "atg_go/pkg/telegram/module"
 
 	"github.com/gin-gonic/gin"
@@ -18,6 +19,11 @@ import (
 func (h *Handler) OrderLinkUpdate(c *gin.Context) {
 	if err := telegrammodule.Modf_OrderLinkUpdate(h.DB); err != nil {
 		log.Printf("[HANDLER ERROR] обновление ссылок: %v", err)
+		httputil.RespondError(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if err := subsfact.SyncWithAccountsFact(h.DB); err != nil {
+		log.Printf("[HANDLER ERROR] синхронизация подписок: %v", err)
 		httputil.RespondError(c, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/subs_fact/subs_fact.go
+++ b/internal/subs_fact/subs_fact.go
@@ -1,0 +1,53 @@
+package subs_fact
+
+import (
+	"log"
+	"math/rand"
+	"time"
+
+	"atg_go/pkg/storage"
+	telegramsubs "atg_go/pkg/telegram/subs_active"
+)
+
+// rnd нужен для пауз между подписками.
+var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// SyncWithAccountsFact приводит количество подписок в order_account_subs
+// в соответствие с полем accounts_number_fact заказа.
+func SyncWithAccountsFact(db *storage.DB) error {
+	orders, err := db.GetOrdersForMonitoring()
+	if err != nil {
+		return err
+	}
+	for _, o := range orders {
+		current, err := db.CountOrderSubs(o.ID)
+		if err != nil {
+			log.Printf("[SUBS_FACT] не удалось получить количество подписок для заказа %d: %v", o.ID, err)
+			continue
+		}
+		if current < o.AccountsNumberFact {
+			need := o.AccountsNumberFact - current
+			accounts, err := db.GetRandomAccountsForOrder(o.ID, need)
+			if err != nil {
+				log.Printf("[SUBS_FACT] не удалось выбрать аккаунты для заказа %d: %v", o.ID, err)
+				continue
+			}
+			for _, acc := range accounts {
+				if err := telegramsubs.SubscribeAccount(db, acc, o.URLDefault); err != nil {
+					log.Printf("[SUBS_FACT] аккаунт %d не смог подписаться на заказ %d: %v", acc.ID, o.ID, err)
+					continue
+				}
+				if err := db.AddOrderAccountSub(o.ID, acc.ID); err != nil {
+					log.Printf("[SUBS_FACT] не удалось записать подписку аккаунта %d на заказ %d: %v", acc.ID, o.ID, err)
+				}
+				time.Sleep(time.Duration(rnd.Intn(3)+2) * time.Second)
+			}
+		} else if current > o.AccountsNumberFact {
+			excess := current - o.AccountsNumberFact
+			if err := db.RemoveOrderAccountSubs(o.ID, excess); err != nil {
+				log.Printf("[SUBS_FACT] не удалось удалить лишние подписки заказа %d: %v", o.ID, err)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/storage/order_account_subs.go
+++ b/pkg/storage/order_account_subs.go
@@ -15,6 +15,15 @@ func (db *DB) AddOrderAccountSub(orderID, accountID int) error {
 	return err
 }
 
+// RemoveOrderAccountSubs удаляет заданное количество подписок для конкретного заказа.
+// Какие записи удалять, значения не имеет, поэтому выбираем произвольные по id.
+func (db *DB) RemoveOrderAccountSubs(orderID, limit int) error {
+	_, err := db.Conn.Exec(`DELETE FROM order_account_subs WHERE id IN (
+        SELECT id FROM order_account_subs WHERE order_id = $1 ORDER BY id DESC LIMIT $2
+    )`, orderID, limit)
+	return err
+}
+
 // GetRandomAccountsForOrder выбирает случайные авторизованные аккаунты,
 // которые ещё не подписаны на канал указанного заказа и не помечены как мониторинговые.
 func (db *DB) GetRandomAccountsForOrder(orderID, limit int) ([]models.Account, error) {


### PR DESCRIPTION
## Summary
- sync order_account_subs with orders.accounts_number_fact on link update
- remove excessive order subscriptions and add missing ones

## Testing
- `go build ./...` *(fails: command exited without output, terminated)*
- `go test ./...` *(fails: command exited without output, terminated)*
- `go vet ./...` *(fails: command exited without output, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e10c143c8327a384d0fbcbe7a865