### PR TITLE
Использование SubsActiveCount для активной аудитории

### DIFF
--- a/internal/module/order_link_update.go
+++ b/internal/module/order_link_update.go
@@ -22,7 +22,7 @@ func (h *Handler) OrderLinkUpdate(c *gin.Context) {
 		httputil.RespondError(c, http.StatusInternalServerError, err.Error())
 		return
 	}
-	if err := subsfact.SyncWithAccountsFact(h.DB); err != nil {
+	if err := subsfact.SyncWithSubsActiveCount(h.DB); err != nil {
 		log.Printf("[HANDLER ERROR] синхронизация подписок: %v", err)
 		httputil.RespondError(c, http.StatusInternalServerError, err.Error())
 		return


### PR DESCRIPTION
## Summary
- расчет просмотров постов основан на числе активных подписчиков
- синхронизация подписок ориентируется на SubsActiveCount

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0e8315a2c8327a5c7bd8952e5cc9e