### PR TITLE
Запрет дублирующих записей в order_account_subs

### DIFF
--- a/migrations/2025-08-28-2310_add_unique_constraint_to_order_account_subs.sql
+++ b/migrations/2025-08-28-2310_add_unique_constraint_to_order_account_subs.sql
@@ -1,0 +1,3 @@
+-- Запрещаем дублирование комбинации order_id и account_id
+ALTER TABLE order_account_subs
+    ADD CONSTRAINT order_account_subs_order_id_account_id_unique UNIQUE (order_id, account_id);

--- a/pkg/storage/order_account_subs.go
+++ b/pkg/storage/order_account_subs.go
@@ -10,8 +10,14 @@ func (db *DB) CountOrderSubs(orderID int) (int, error) {
 }
 
 // AddOrderAccountSub сохраняет факт подписки аккаунта на канал заказа.
+// Используем ON CONFLICT, чтобы игнорировать повторные записи без ошибки.
 func (db *DB) AddOrderAccountSub(orderID, accountID int) error {
-	_, err := db.Conn.Exec(`INSERT INTO order_account_subs (order_id, account_id) VALUES ($1, $2)`, orderID, accountID)
+	_, err := db.Conn.Exec(
+		`INSERT INTO order_account_subs (order_id, account_id)
+                VALUES ($1, $2)
+                ON CONFLICT DO NOTHING`,
+		orderID, accountID,
+	)
 	return err
 }
 

--- a/pkg/storage/order_account_subs_test.go
+++ b/pkg/storage/order_account_subs_test.go
@@ -1,0 +1,33 @@
+package storage
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+)
+
+// TestAddOrderAccountSubDuplicate проверяет, что повторная вставка одинаковых
+// подписок не вызывает ошибку и запрос содержит ON CONFLICT DO NOTHING.
+func TestAddOrderAccountSubDuplicate(t *testing.T) {
+	executedQueries = nil
+	db, err := sql.Open("dummy", "")
+	if err != nil {
+		t.Fatalf("не удалось открыть фейковую БД: %v", err)
+	}
+	storageDB := &DB{Conn: db}
+
+	if err := storageDB.AddOrderAccountSub(1, 2); err != nil {
+		t.Fatalf("первая вставка завершилась ошибкой: %v", err)
+	}
+	if err := storageDB.AddOrderAccountSub(1, 2); err != nil {
+		t.Fatalf("повторная вставка завершилась ошибкой: %v", err)
+	}
+	if len(executedQueries) != 2 {
+		t.Fatalf("ожидалось 2 запроса, получено %d", len(executedQueries))
+	}
+	for _, q := range executedQueries {
+		if !strings.Contains(q, "ON CONFLICT DO NOTHING") {
+			t.Fatalf("в запросе отсутствует ON CONFLICT DO NOTHING: %s", q)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- запретил дублирование сочетаний order_id и account_id в order_account_subs
- защитил вставку подписок от повторов через ON CONFLICT
- добавил тест, проверяющий отсутствие дублирующих подписок

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0f66ae6588327b14d22c710601f2e