### PR TITLE
Rename donor fields in channel_duplicate

### DIFF
--- a/migrations/2025-08-29-1717_rename_channel_duplicate_fields.sql
+++ b/migrations/2025-08-29-1717_rename_channel_duplicate_fields.sql
@@ -1,0 +1,6 @@
+-- Переименование полей источника в channel_duplicate
+ALTER TABLE channel_duplicate
+    RENAME COLUMN url_channel_duplicate TO url_channel_donor;
+ALTER TABLE channel_duplicate
+    RENAME COLUMN channel_duplicate_tgid TO channel_donor_tgid;
+

--- a/models/channel_duplicate.go
+++ b/models/channel_duplicate.go
@@ -2,18 +2,18 @@ package models
 
 // ChannelDuplicate описывает канал-источник, контент которого нужно дублировать
 // order_id - идентификатор заказа; при удалении заказа запись удаляется каскадно
-// url_channel_duplicate - ссылка на канал-источник
-// channel_duplicate_tgid - ID телеграм-канала источника
+// url_channel_donor - ссылка на канал-источник
+// channel_donor_tgid - ID телеграм-канала источника
 // post_text_remove - текст, который нужно удалить из поста
 // post_text_add - текст, который нужно добавить в конец поста
 //
 // Комментарии в коде на русском языке по требованию пользователя
 
 type ChannelDuplicate struct {
-	ID                   int     `json:"id"`
-	OrderID              int     `json:"order_id"`               // ID связанного заказа
-	URLChannelDuplicate  string  `json:"url_channel_duplicate"`  // Ссылка на канал-источник
-	ChannelDuplicateTGID *string `json:"channel_duplicate_tgid"` // ID телеграм-канала источника
-	PostTextRemove       *string `json:"post_text_remove"`       // Текст для удаления
-	PostTextAdd          *string `json:"post_text_add"`          // Текст для добавления
+	ID               int     `json:"id"`
+	OrderID          int     `json:"order_id"`           // ID связанного заказа
+	URLChannelDonor  string  `json:"url_channel_donor"`  // Ссылка на канал-источник
+	ChannelDonorTGID *string `json:"channel_donor_tgid"` // ID телеграм-канала источника
+	PostTextRemove   *string `json:"post_text_remove"`   // Текст для удаления
+	PostTextAdd      *string `json:"post_text_add"`      // Текст для добавления
 }


### PR DESCRIPTION
## Summary
- rename donor fields in ChannelDuplicate model
- add migration to rename donor columns

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1e08613808327ba8a0a14f3525b3d