### PR TITLE
feat: forward donor channel posts

### DIFF
--- a/internal/channel_duplicate/channel_duplicate.go
+++ b/internal/channel_duplicate/channel_duplicate.go
@@ -1,0 +1,12 @@
+package channel_duplicate
+
+import (
+	"atg_go/pkg/storage"
+	tgdup "atg_go/pkg/telegram/channel_duplicate"
+)
+
+// Run запускает фоновую пересылку постов с донорских каналов.
+// Работает, пока активен сервер.
+func Run(db *storage.DB) {
+	tgdup.Start(db)
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"atg_go/internal/auth"
+	chduplicate "atg_go/internal/channel_duplicate"
 	"atg_go/internal/comments"
 	"atg_go/internal/middleware"
 	module "atg_go/internal/module"
@@ -40,8 +41,9 @@ func main() {
 	db := storage.NewDB(dbConn)               // Для работы с аккаунтами
 	commentDB := storage.NewCommentDB(dbConn) // Для работы с каналами
 
-	// Запускаем фоновый мониторинг каналов заказов
+	// Запускаем фоновые процессы мониторинга и дублирования
 	monitoring.Run(db)
+	chduplicate.Run(db)
 
 	// Настройка роутера
 	r := setupRouter(db, commentDB)

--- a/migrations/2025-08-29-1800_add_last_post_id_channel_duplicate.sql
+++ b/migrations/2025-08-29-1800_add_last_post_id_channel_duplicate.sql
@@ -1,0 +1,3 @@
+-- Добавление поля для отслеживания последнего пересланного поста
+ALTER TABLE channel_duplicate
+    ADD COLUMN last_post_id INTEGER DEFAULT NULL;

--- a/models/channel_duplicate.go
+++ b/models/channel_duplicate.go
@@ -16,4 +16,5 @@ type ChannelDuplicate struct {
 	ChannelDonorTGID *string `json:"channel_donor_tgid"` // ID телеграм-канала источника
 	PostTextRemove   *string `json:"post_text_remove"`   // Текст для удаления
 	PostTextAdd      *string `json:"post_text_add"`      // Текст для добавления
+	LastPostID       *int    `json:"last_post_id"`       // ID последнего пересланного поста
 }

--- a/pkg/storage/channel_duplicate.go
+++ b/pkg/storage/channel_duplicate.go
@@ -1,0 +1,81 @@
+package storage
+
+import (
+	"database/sql"
+
+	"atg_go/models"
+)
+
+// ChannelDuplicateOrder объединяет запись дублирования с адресом нашего канала.
+type ChannelDuplicateOrder struct {
+	models.ChannelDuplicate
+	OrderURL         string  // Ссылка на наш канал (Order.URLDefault)
+	OrderChannelTGID *string // ID нашего канала
+}
+
+// GetChannelDuplicates возвращает список каналов-источников и связанные с ними заказы.
+func (db *DB) GetChannelDuplicates() ([]ChannelDuplicateOrder, error) {
+	rows, err := db.Conn.Query(`
+                SELECT cd.id, cd.order_id, cd.url_channel_donor, cd.channel_donor_tgid, cd.post_text_remove, cd.post_text_add, cd.last_post_id,
+                       o.url_default, o.channel_tgid
+                FROM channel_duplicate cd
+                JOIN orders o ON cd.order_id = o.id
+                WHERE cd.url_channel_donor <> '' AND o.url_default <> ''`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var list []ChannelDuplicateOrder
+	for rows.Next() {
+		var cd ChannelDuplicateOrder
+		var (
+			donorTGID, postRemove, postAdd, orderTGID sql.NullString
+			lastPost                                  sql.NullInt64
+		)
+		if err := rows.Scan(&cd.ID, &cd.OrderID, &cd.URLChannelDonor, &donorTGID, &postRemove, &postAdd, &lastPost, &cd.OrderURL, &orderTGID); err != nil {
+			return nil, err
+		}
+		if donorTGID.Valid {
+			cd.ChannelDonorTGID = &donorTGID.String
+		}
+		if postRemove.Valid {
+			cd.PostTextRemove = &postRemove.String
+		}
+		if postAdd.Valid {
+			cd.PostTextAdd = &postAdd.String
+		}
+		if lastPost.Valid {
+			v := int(lastPost.Int64)
+			cd.LastPostID = &v
+		}
+		if orderTGID.Valid {
+			cd.OrderChannelTGID = &orderTGID.String
+		}
+		list = append(list, cd)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+// SetChannelDonorTGID сохраняет ID донорского канала.
+func (db *DB) SetChannelDonorTGID(id int, tgid string) error {
+	_, err := db.Conn.Exec(`UPDATE channel_duplicate SET channel_donor_tgid = $1 WHERE id = $2`, tgid, id)
+	return err
+}
+
+// TrySetLastPostID обновляет last_post_id, если сообщение новое.
+// Возвращает true, если обновление выполнено.
+func (db *DB) TrySetLastPostID(id int, postID int) (bool, error) {
+	res, err := db.Conn.Exec(`UPDATE channel_duplicate SET last_post_id = $2 WHERE id = $1 AND (last_post_id IS NULL OR last_post_id < $2)`, id, postID)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}

--- a/pkg/telegram/channel_duplicate/channel_duplicate.go
+++ b/pkg/telegram/channel_duplicate/channel_duplicate.go
@@ -1,0 +1,171 @@
+package channel_duplicate
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/rand"
+	"strings"
+	"time"
+
+	"atg_go/pkg/storage"
+	base "atg_go/pkg/telegram/module"
+	accountmutex "atg_go/pkg/telegram/module/account_mutex"
+
+	"github.com/gotd/td/tg"
+)
+
+// channelInfo хранит данные для пересылки сообщений.
+type channelInfo struct {
+	id     int
+	donor  *tg.Channel
+	target *tg.Channel
+}
+
+// Start запускает отслеживание донорских каналов и пересылку постов.
+func Start(db *storage.DB) {
+	go func() {
+		if err := run(db); err != nil {
+			log.Printf("[CHANNEL DUPLICATE] остановлено: %v", err)
+		}
+	}()
+}
+
+// run выполняет основную работу по пересылке постов.
+func run(db *storage.DB) error {
+	rand.Seed(time.Now().UnixNano())
+	accounts, err := db.GetMonitoringAccounts()
+	if err != nil {
+		return err
+	}
+	if len(accounts) == 0 {
+		return fmt.Errorf("нет аккаунтов для мониторинга")
+	}
+	acc := accounts[0]
+	if err := accountmutex.LockAccount(acc.ID); err != nil {
+		return err
+	}
+	defer accountmutex.UnlockAccount(acc.ID)
+
+	dups, err := db.GetChannelDuplicates()
+	if err != nil {
+		return err
+	}
+	if len(dups) == 0 {
+		return fmt.Errorf("нет каналов для дублирования")
+	}
+
+	dispatcher := tg.NewUpdateDispatcher()
+	chMap := make(map[int64]channelInfo)
+	var api *tg.Client
+
+	dispatcher.OnNewChannelMessage(func(ctx context.Context, e tg.Entities, upd *tg.UpdateNewChannelMessage) error {
+		msg, ok := upd.Message.(*tg.Message)
+		if !ok {
+			return nil
+		}
+		peer, ok := msg.PeerID.(*tg.PeerChannel)
+		if !ok {
+			return nil
+		}
+		info, ok := chMap[peer.ChannelID]
+		if !ok {
+			return nil
+		}
+		updated, err := db.TrySetLastPostID(info.id, msg.ID)
+		if err != nil {
+			log.Printf("[CHANNEL DUPLICATE] обновление last_post_id: %v", err)
+			return nil
+		}
+		if !updated {
+			return nil
+		}
+		for i := 0; i < 3; i++ {
+			_, err = api.MessagesForwardMessages(ctx, &tg.MessagesForwardMessagesRequest{
+				FromPeer: &tg.InputPeerChannel{ChannelID: info.donor.ID, AccessHash: info.donor.AccessHash},
+				ID:       []int{msg.ID},
+				ToPeer:   &tg.InputPeerChannel{ChannelID: info.target.ID, AccessHash: info.target.AccessHash},
+				RandomID: []int64{rand.Int63()},
+			})
+			if err == nil {
+				return nil
+			}
+			if i == 2 {
+				saveErr := db.SaveSos(fmt.Sprintf("не удалось переслать пост %d с канала %d: %v", msg.ID, info.donor.ID, err))
+				if saveErr != nil {
+					log.Printf("[CHANNEL DUPLICATE] ошибка записи в Sos: %v", saveErr)
+				}
+			}
+			time.Sleep(2 * time.Second)
+		}
+		return nil
+	})
+
+	client, err := base.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, dispatcher)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	return client.Run(ctx, func(ctx context.Context) error {
+		api = tg.NewClient(client)
+		for _, cd := range dups {
+			donorUser, err := base.Modf_ExtractUsername(cd.URLChannelDonor)
+			if err != nil {
+				log.Printf("[CHANNEL DUPLICATE] некорректная ссылка %s: %v", cd.URLChannelDonor, err)
+				continue
+			}
+			donorResolved, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: donorUser})
+			if err != nil {
+				log.Printf("[CHANNEL DUPLICATE] не удалось получить канал %s: %v", cd.URLChannelDonor, err)
+				continue
+			}
+			donorCh, err := base.Modf_FindChannel(donorResolved.GetChats())
+			if err != nil {
+				log.Printf("[CHANNEL DUPLICATE] канал %s не найден: %v", cd.URLChannelDonor, err)
+				continue
+			}
+			if err := base.Modf_JoinChannel(ctx, api, donorCh, db, acc.ID); err != nil && !strings.Contains(err.Error(), "USER_ALREADY_PARTICIPANT") {
+				log.Printf("[CHANNEL DUPLICATE] подписка на %s: %v", cd.URLChannelDonor, err)
+				continue
+			}
+			settings := tg.InputPeerNotifySettings{}
+			settings.SetMuteUntil(0)
+			_, err = api.AccountUpdateNotifySettings(ctx, &tg.AccountUpdateNotifySettingsRequest{
+				Peer:     &tg.InputNotifyPeer{Peer: &tg.InputPeerChannel{ChannelID: donorCh.ID, AccessHash: donorCh.AccessHash}},
+				Settings: settings,
+			})
+			if err != nil {
+				log.Printf("[CHANNEL DUPLICATE] уведомления %s: %v", cd.URLChannelDonor, err)
+			}
+			if cd.ChannelDonorTGID == nil {
+				_ = db.SetChannelDonorTGID(cd.ID, fmt.Sprintf("%d", donorCh.ID))
+			}
+
+			targetUser, err := base.Modf_ExtractUsername(cd.OrderURL)
+			if err != nil {
+				log.Printf("[CHANNEL DUPLICATE] некорректная ссылка %s: %v", cd.OrderURL, err)
+				continue
+			}
+			targetResolved, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: targetUser})
+			if err != nil {
+				log.Printf("[CHANNEL DUPLICATE] не удалось получить канал %s: %v", cd.OrderURL, err)
+				continue
+			}
+			targetCh, err := base.Modf_FindChannel(targetResolved.GetChats())
+			if err != nil {
+				log.Printf("[CHANNEL DUPLICATE] канал %s не найден: %v", cd.OrderURL, err)
+				continue
+			}
+			if err := base.Modf_JoinChannel(ctx, api, targetCh, db, acc.ID); err != nil && !strings.Contains(err.Error(), "USER_ALREADY_PARTICIPANT") {
+				log.Printf("[CHANNEL DUPLICATE] подписка на %s: %v", cd.OrderURL, err)
+			}
+			if cd.OrderChannelTGID == nil {
+				_ = db.SetOrderChannelTGID(cd.OrderID, fmt.Sprintf("%d", targetCh.ID))
+			}
+			chMap[donorCh.ID] = channelInfo{id: cd.ID, donor: donorCh, target: targetCh}
+		}
+		<-ctx.Done()
+		return nil
+	})
+}


### PR DESCRIPTION
## Summary
- add last_post_id column for channel duplicate tracking
- forward posts from donor channels to target orders with retries
- integrate channel duplication background process

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1e423ed508327ac8ad0072a5deebd