### PR TITLE
Пропуск рекламных постов в channel_duplicate

### DIFF
--- a/pkg/telegram/channel_duplicate/advertisement.go
+++ b/pkg/telegram/channel_duplicate/advertisement.go
@@ -1,0 +1,56 @@
+package channel_duplicate
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/gotd/td/tg"
+)
+
+// linkPattern ищет ссылки в тексте поста.
+var linkPattern = regexp.MustCompile(`https?://\S+`)
+
+// isAdvertisement определяет, содержит ли сообщение признаки рекламы.
+func isAdvertisement(msg *tg.Message) bool {
+	text := strings.ToLower(msg.Message)
+
+	// Проверяем ключевые слова в тексте
+	if strings.Contains(text, "erid") || strings.Contains(text, "ерид") {
+		return true
+	}
+	if strings.Contains(text, "#реклама") || strings.Contains(text, "#sponsored") || strings.Contains(text, "#ad") {
+		return true
+	}
+
+	// Проверяем все ссылки в сообщении
+	links := extractLinks(msg)
+	for _, l := range links {
+		lower := strings.ToLower(l)
+		if strings.Contains(lower, "erid") || strings.Contains(lower, "ерид") {
+			return true
+		}
+		u, err := url.Parse(l)
+		if err != nil {
+			continue
+		}
+		switch strings.ToLower(u.Query().Get("utm_medium")) {
+		case "influencer", "sponsor", "ed", "ads", "promo", "pr", "native":
+			return true
+		}
+	}
+
+	return false
+}
+
+// extractLinks возвращает все ссылки из сообщения.
+func extractLinks(msg *tg.Message) []string {
+	var links []string
+	links = append(links, linkPattern.FindAllString(msg.Message, -1)...)
+	for _, e := range msg.Entities {
+		if t, ok := e.(*tg.MessageEntityTextURL); ok {
+			links = append(links, t.URL)
+		}
+	}
+	return links
+}

--- a/pkg/telegram/channel_duplicate/advertisement_test.go
+++ b/pkg/telegram/channel_duplicate/advertisement_test.go
@@ -1,0 +1,45 @@
+package channel_duplicate
+
+import (
+	"testing"
+
+	"github.com/gotd/td/tg"
+)
+
+// TestIsAdvertisement проверяет определение рекламных постов.
+func TestIsAdvertisement(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *tg.Message
+		want bool
+	}{
+		{
+			name: "хештег",
+			msg:  &tg.Message{Message: "текст #реклама"},
+			want: true,
+		},
+		{
+			name: "utm_medium",
+			msg:  &tg.Message{Message: "https://example.com?utm_medium=promo"},
+			want: true,
+		},
+		{
+			name: "erid в ссылке",
+			msg: &tg.Message{Message: "смотри", Entities: []tg.MessageEntityClass{
+				&tg.MessageEntityTextURL{URL: "https://a.com?erid=123"},
+			}},
+			want: true,
+		},
+		{
+			name: "чистый",
+			msg:  &tg.Message{Message: "привет мир"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		if got := isAdvertisement(tt.msg); got != tt.want {
+			t.Errorf("%s: ожидалось %v, получено %v", tt.name, tt.want, got)
+		}
+	}
+}

--- a/pkg/telegram/channel_duplicate/channel_duplicate.go
+++ b/pkg/telegram/channel_duplicate/channel_duplicate.go
@@ -57,6 +57,10 @@ func Connect(ctx context.Context, api *tg.Client, dispatcher *tg.UpdateDispatche
 		if !updated {
 			return nil
 		}
+		// Перед пересылкой проверяем пост на признаки рекламы
+		if isAdvertisement(msg) {
+			return nil
+		}
 		for i := 0; i < 3; i++ {
 			_, err = api.MessagesForwardMessages(ctx, &tg.MessagesForwardMessagesRequest{
 				FromPeer: &tg.InputPeerChannel{ChannelID: info.donor.ID, AccessHash: info.donor.AccessHash},


### PR DESCRIPTION
## Summary
- добавлена проверка сообщений на признаки рекламы перед пересылкой
- реализована логика фильтрации рекламных ссылок и хештегов
- добавлены тесты для проверки фильтрации

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b2f163eaf08327a2336029752aae0b