### PR TITLE
Не фильтровать пересланные посты при дублировании каналов

### DIFF
--- a/pkg/telegram/channel_duplicate/advertisement.go
+++ b/pkg/telegram/channel_duplicate/advertisement.go
@@ -14,20 +14,7 @@ var linkPattern = regexp.MustCompile(`https?://\S+`)
 // isAdvertisement определяет, содержит ли сообщение признаки рекламы.
 func isAdvertisement(msg *tg.Message) bool {
 	text := strings.ToLower(msg.Message)
-
-	// Проверяем, что сообщение не переслано из другого канала
-	if fwd, ok := msg.GetFwdFrom(); ok {
-		// Forwarded из канала определяем по наличию ChannelPost
-		if _, ok := fwd.GetChannelPost(); ok {
-			return true
-		}
-		// или если источник указан как PeerChannel
-		if from, ok := fwd.GetFromID(); ok {
-			if _, ok := from.(*tg.PeerChannel); ok {
-				return true
-			}
-		}
-	}
+	// Пересланные сообщения считаем обычными, поэтому их не проверяем отдельно
 
 	// Проверяем ключевые слова в тексте
 	if strings.Contains(text, "erid") || strings.Contains(text, "ерид") {

--- a/pkg/telegram/channel_duplicate/advertisement_test.go
+++ b/pkg/telegram/channel_duplicate/advertisement_test.go
@@ -32,7 +32,7 @@ func TestIsAdvertisement(t *testing.T) {
 				m.SetFwdFrom(f)
 				return m
 			}(),
-			want: true,
+			want: false,
 		},
 		{
 			name: "erid в ссылке",


### PR DESCRIPTION
## Summary
- не считать пересланные сообщения рекламой при дублировании
- обновить тесты на проверку рекламы

## Testing
- `go test ./...` *(зависло: не удалось получить вывод)*

------
https://chatgpt.com/codex/tasks/task_e_68b300954cb88327a55cf1a20ea7d31c