### PR TITLE
Обновление текстов в channel_duplicate без перезапуска

### DIFF
--- a/pkg/telegram/channel_duplicate/channel_duplicate.go
+++ b/pkg/telegram/channel_duplicate/channel_duplicate.go
@@ -97,7 +97,7 @@ func Connect(ctx context.Context, api *tg.Client, dispatcher *tg.UpdateDispatche
 		if !ok {
 			return nil
 		}
-		updated, err := db.TrySetLastPostID(info.id, msg.ID)
+		updated, remove, add, err := db.TrySetLastPostID(info.id, msg.ID)
 		if err != nil {
 			log.Printf("[CHANNEL DUPLICATE] обновление last_post_id: %v", err)
 			return nil
@@ -105,6 +105,10 @@ func Connect(ctx context.Context, api *tg.Client, dispatcher *tg.UpdateDispatche
 		if !updated {
 			return nil
 		}
+		// Обновляем тексты в карте, чтобы использовать свежие значения
+		info.remove = remove
+		info.add = add
+		chMap[peer.ChannelID] = info
 		// Перед пересылкой проверяем пост на признаки рекламы
 		if isAdvertisement(msg) {
 			return nil


### PR DESCRIPTION
## Summary
- возвращаем свежие PostTextRemove/PostTextAdd из БД
- используем актуальные значения при обработке новых сообщений

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b30aa10a808327bc9218fb6c6f0df5