### PR TITLE
Обработка ссылок в PostTextAdd

### DIFF
--- a/models/channel_duplicate.go
+++ b/models/channel_duplicate.go
@@ -6,6 +6,7 @@ package models
 // channel_donor_tgid - ID телеграм-канала источника
 // post_text_remove - текст, который нужно удалить из поста
 // post_text_add - текст, который нужно добавить в конец поста
+//                Ссылки задаются в формате [текст](url)
 //
 // Комментарии в коде на русском языке по требованию пользователя
 
@@ -15,6 +16,6 @@ type ChannelDuplicate struct {
 	URLChannelDonor  string  `json:"url_channel_donor"`  // Ссылка на канал-источник
 	ChannelDonorTGID *string `json:"channel_donor_tgid"` // ID телеграм-канала источника
 	PostTextRemove   *string `json:"post_text_remove"`   // Текст для удаления
-	PostTextAdd      *string `json:"post_text_add"`      // Текст для добавления
+	PostTextAdd      *string `json:"post_text_add"`      // Текст для добавления; ссылки: [текст](url)
 	LastPostID       *int    `json:"last_post_id"`       // ID последнего пересланного поста
 }

--- a/pkg/telegram/channel_duplicate/channel_duplicate.go
+++ b/pkg/telegram/channel_duplicate/channel_duplicate.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"atg_go/pkg/storage"
 	base "atg_go/pkg/telegram/module"
@@ -63,6 +65,22 @@ func forwardScheduled(ctx context.Context, api *tg.Client, donor *tg.Channel, ta
 		}
 	}
 	return 0, fmt.Errorf("ID отложенного сообщения не найден")
+}
+
+// parseTextURL ищет в тексте ссылку формата [текст](url)
+// и возвращает сущность для Telegram и очищенный текст без служебных символов.
+func parseTextURL(text string, baseOffset int) (*tg.MessageEntityTextURL, string) {
+	markdown := regexp.MustCompile(`\[([^\]]+)\]\((https?://[^\s]+)\)`)
+	if loc := markdown.FindStringSubmatchIndex(text); loc != nil {
+		visible := text[loc[2]:loc[3]]
+		url := text[loc[4]:loc[5]]
+		offset := baseOffset + utf8.RuneCountInString(text[:loc[2]])
+		length := utf8.RuneCountInString(visible)
+		clean := text[:loc[0]] + visible + text[loc[1]:]
+		ent := &tg.MessageEntityTextURL{Offset: offset, Length: length, URL: url}
+		return ent, clean
+	}
+	return nil, text
 }
 
 // Connect присоединяет модуль дублирования каналов к существующему клиенту Telegram.
@@ -137,9 +155,13 @@ func Connect(ctx context.Context, api *tg.Client, dispatcher *tg.UpdateDispatche
 				return nil
 			}
 		}
+		// Сохраняем текст после удаления, чтобы знать смещение добавленного блока
+		baseText := text
+		var addText string
 		if info.add != nil && *info.add != "" {
 			// Добавляем текст в конец поста
-			text += *info.add
+			addText = *info.add
+			text = baseText + addText
 			needsEdit = true
 		}
 
@@ -159,6 +181,13 @@ func Connect(ctx context.Context, api *tg.Client, dispatcher *tg.UpdateDispatche
 				ID:   forwardedID,
 			}
 			editReq.SetMessage(text)
+			// Анализируем добавленный текст на наличие ссылки и формируем сущность
+			if addText != "" {
+				if ent, clean := parseTextURL(addText, utf8.RuneCountInString(baseText)); ent != nil {
+					editReq.SetMessage(baseText + clean)
+					editReq.SetEntities([]tg.MessageEntityClass{ent})
+				}
+			}
 			editReq.SetScheduleDate(schedule)
 			if _, err = api.MessagesEditMessage(ctx, &editReq); err != nil {
 				log.Printf("[CHANNEL DUPLICATE] редактирование сообщения: %v", err)


### PR DESCRIPTION
## Summary
- поддержка ссылок только в формате `[текст](url)`
- при редактировании отложенного поста ссылка добавляется через `MessageEntityTextURL`
- документировано использование формата `[текст](url)` для `PostTextAdd`

## Testing
- `go test ./...` (зависает, прервано вручную)


------
https://chatgpt.com/codex/tasks/task_e_68b374158380832797f5805cdf5a36f0