### PR TITLE
Обработка ссылок в PostTextAdd

### DIFF
--- a/models/channel_duplicate.go
+++ b/models/channel_duplicate.go
@@ -6,6 +6,7 @@ package models
 // channel_donor_tgid - ID телеграм-канала источника
 // post_text_remove - текст, который нужно удалить из поста
 // post_text_add - текст, который нужно добавить в конец поста
+//                Ссылки задаются в формате [текст](url)
 //
 // Комментарии в коде на русском языке по требованию пользователя
 
@@ -15,6 +16,6 @@ type ChannelDuplicate struct {
 	URLChannelDonor  string  `json:"url_channel_donor"`  // Ссылка на канал-источник
 	ChannelDonorTGID *string `json:"channel_donor_tgid"` // ID телеграм-канала источника
 	PostTextRemove   *string `json:"post_text_remove"`   // Текст для удаления
-	PostTextAdd      *string `json:"post_text_add"`      // Текст для добавления
+	PostTextAdd      *string `json:"post_text_add"`      // Текст для добавления; ссылки: [текст](url)
 	LastPostID       *int    `json:"last_post_id"`       // ID последнего пересланного поста
 }

--- a/pkg/telegram/channel_duplicate/parse_test.go
+++ b/pkg/telegram/channel_duplicate/parse_test.go
@@ -1,0 +1,22 @@
+package channel_duplicate
+
+import "testing"
+
+// TestParseTextURL проверяет корректность вычисления смещений в UTF-16.
+func TestParseTextURL(t *testing.T) {
+	base := "😀Привет" // emoji занимает две позиции UTF-16
+	add := "[Мир](https://example.com)"
+	ent, clean := parseTextURL(add, utf16Len(base))
+	if ent == nil {
+		t.Fatalf("сущность не найдена")
+	}
+	if ent.Offset != utf16Len(base) {
+		t.Errorf("ожидался offset %d, получен %d", utf16Len(base), ent.Offset)
+	}
+	if ent.Length != utf16Len("Мир") {
+		t.Errorf("ожидалась длина %d, получена %d", utf16Len("Мир"), ent.Length)
+	}
+	if clean != "Мир" {
+		t.Errorf("ожидался текст 'Мир', получено %q", clean)
+	}
+}


### PR DESCRIPTION
## Summary
- смещения и длины ссылок считаются в UTF-16, что позволяет корректно редактировать отложенные посты
- добавлен юнит‑тест для проверки вычисления смещений

## Testing
- `go test ./pkg/telegram/channel_duplicate -run TestParseTextURL -count=1 -v` (зависает, прервано вручную)


------
https://chatgpt.com/codex/tasks/task_e_68b374158380832797f5805cdf5a36f0