### PR TITLE
feat: расширено логирование редактирования отложенных постов

### DIFF
--- a/models/channel_duplicate.go
+++ b/models/channel_duplicate.go
@@ -6,6 +6,7 @@ package models
 // channel_donor_tgid - ID телеграм-канала источника
 // post_text_remove - текст, который нужно удалить из поста
 // post_text_add - текст, который нужно добавить в конец поста
+//                Ссылки задаются в формате [текст](url)
 //
 // Комментарии в коде на русском языке по требованию пользователя
 
@@ -15,6 +16,6 @@ type ChannelDuplicate struct {
 	URLChannelDonor  string  `json:"url_channel_donor"`  // Ссылка на канал-источник
 	ChannelDonorTGID *string `json:"channel_donor_tgid"` // ID телеграм-канала источника
 	PostTextRemove   *string `json:"post_text_remove"`   // Текст для удаления
-	PostTextAdd      *string `json:"post_text_add"`      // Текст для добавления
+	PostTextAdd      *string `json:"post_text_add"`      // Текст для добавления; ссылки: [текст](url)
 	LastPostID       *int    `json:"last_post_id"`       // ID последнего пересланного поста
 }

--- a/pkg/telegram/channel_duplicate/channel_duplicate.go
+++ b/pkg/telegram/channel_duplicate/channel_duplicate.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"regexp"
 	"strings"
 	"time"
+	"unicode/utf16"
 
 	"atg_go/pkg/storage"
 	base "atg_go/pkg/telegram/module"
@@ -63,6 +65,30 @@ func forwardScheduled(ctx context.Context, api *tg.Client, donor *tg.Channel, ta
 		}
 	}
 	return 0, fmt.Errorf("ID отложенного сообщения не найден")
+}
+
+// utf16Len возвращает длину строки в кодовых единицах UTF-16.
+// Telegram измеряет смещения сущностей именно в этих единицах.
+func utf16Len(s string) int {
+	return len(utf16.Encode([]rune(s)))
+}
+
+// parseTextURL ищет в тексте ссылку формата [текст](url)
+// и возвращает сущность для Telegram и очищенный текст без служебных символов.
+func parseTextURL(text string, baseOffset int) (*tg.MessageEntityTextURL, string) {
+	markdown := regexp.MustCompile(`\[([^\]]+)\]\((https?://[^\s]+)\)`)
+	if loc := markdown.FindStringSubmatchIndex(text); loc != nil {
+		visible := text[loc[2]:loc[3]]
+		url := text[loc[4]:loc[5]]
+		// Смещения считаются в UTF-16, поэтому используем utf16Len
+		// Offset указывает на позицию видимого текста без учёта служебных символов
+		offset := baseOffset + utf16Len(text[:loc[0]])
+		length := utf16Len(visible)
+		clean := text[:loc[0]] + visible + text[loc[1]:]
+		ent := &tg.MessageEntityTextURL{Offset: offset, Length: length, URL: url}
+		return ent, clean
+	}
+	return nil, text
 }
 
 // Connect присоединяет модуль дублирования каналов к существующему клиенту Telegram.
@@ -137,9 +163,13 @@ func Connect(ctx context.Context, api *tg.Client, dispatcher *tg.UpdateDispatche
 				return nil
 			}
 		}
+		// Сохраняем текст после удаления, чтобы знать смещение добавленного блока
+		baseText := text
+		var addText string
 		if info.add != nil && *info.add != "" {
 			// Добавляем текст в конец поста
-			text += *info.add
+			addText = *info.add
+			text = baseText + addText
 			needsEdit = true
 		}
 
@@ -154,21 +184,47 @@ func Connect(ctx context.Context, api *tg.Client, dispatcher *tg.UpdateDispatche
 				}
 				return nil
 			}
+			// Логируем ID отложенного сообщения
+			log.Printf("[CHANNEL DUPLICATE] пост %d сохранён в отложенных как %d", msg.ID, forwardedID)
+
+			editText := text
+			var entities []tg.MessageEntityClass
+			// Анализируем добавленный текст на наличие ссылки и формируем сущность
+			if addText != "" {
+				if ent, clean := parseTextURL(addText, utf16Len(baseText)); ent != nil {
+					// Логируем параметры найденной ссылки
+					log.Printf("[CHANNEL DUPLICATE] найдена ссылка offset=%d длина=%d url=%s", ent.Offset, ent.Length, ent.URL)
+					editText = baseText + clean
+					entities = []tg.MessageEntityClass{ent}
+				} else {
+					log.Printf("[CHANNEL DUPLICATE] ссылка в добавке не обнаружена")
+				}
+			}
 			editReq := tg.MessagesEditMessageRequest{
 				Peer: &tg.InputPeerChannel{ChannelID: info.target.ID, AccessHash: info.target.AccessHash},
 				ID:   forwardedID,
 			}
-			editReq.SetMessage(text)
+			editReq.SetMessage(editText)
+			if len(entities) > 0 {
+				editReq.SetEntities(entities)
+			}
 			editReq.SetScheduleDate(schedule)
+			// Отражаем подготовку запроса редактирования
+			log.Printf("[CHANNEL DUPLICATE] редактирование отложенного поста %d (сущностей %d)", forwardedID, len(entities))
 			if _, err = api.MessagesEditMessage(ctx, &editReq); err != nil {
 				log.Printf("[CHANNEL DUPLICATE] редактирование сообщения: %v", err)
 				return nil
 			}
+			log.Printf("[CHANNEL DUPLICATE] отложенный пост %d отредактирован", forwardedID)
+
+			log.Printf("[CHANNEL DUPLICATE] публикация отложенного поста %d", forwardedID)
 			if _, err = api.MessagesSendScheduledMessages(ctx, &tg.MessagesSendScheduledMessagesRequest{
 				Peer: &tg.InputPeerChannel{ChannelID: info.target.ID, AccessHash: info.target.AccessHash},
 				ID:   []int{forwardedID},
 			}); err != nil {
 				log.Printf("[CHANNEL DUPLICATE] публикация отложенного сообщения: %v", err)
+			} else {
+				log.Printf("[CHANNEL DUPLICATE] отложенный пост %d опубликован", forwardedID)
 			}
 			return nil
 		}

--- a/pkg/telegram/channel_duplicate/parse_test.go
+++ b/pkg/telegram/channel_duplicate/parse_test.go
@@ -1,0 +1,22 @@
+package channel_duplicate
+
+import "testing"
+
+// TestParseTextURL проверяет корректность вычисления смещений в UTF-16.
+func TestParseTextURL(t *testing.T) {
+	base := "😀Привет" // emoji занимает две позиции UTF-16
+	add := "[Мир](https://example.com)"
+	ent, clean := parseTextURL(add, utf16Len(base))
+	if ent == nil {
+		t.Fatalf("сущность не найдена")
+	}
+	if ent.Offset != utf16Len(base) {
+		t.Errorf("ожидался offset %d, получен %d", utf16Len(base), ent.Offset)
+	}
+	if ent.Length != utf16Len("Мир") {
+		t.Errorf("ожидалась длина %d, получена %d", utf16Len("Мир"), ent.Length)
+	}
+	if clean != "Мир" {
+		t.Errorf("ожидался текст 'Мир', получено %q", clean)
+	}
+}


### PR DESCRIPTION
## Summary
- логируем параметры найденной ссылки
- фиксируем количество сущностей при редактировании отложенного поста

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b374158380832797f5805cdf5a36f0