### PR TITLE
Исправлен парсинг ссылок при дублировании каналов

### DIFF
--- a/pkg/telegram/channel_duplicate/channel_duplicate.go
+++ b/pkg/telegram/channel_duplicate/channel_duplicate.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
-	"regexp"
 	"strings"
 	"time"
-	"unicode/utf16"
 
 	"atg_go/pkg/storage"
 	base "atg_go/pkg/telegram/module"
@@ -147,6 +145,17 @@ func Connect(ctx context.Context, api *tg.Client, dispatcher *tg.UpdateDispatche
 			addText = *info.add
 			text = baseText + addText
 			needsEdit = true
+		}
+
+		// Готовим текст и сущности для редактирования
+		editText := text
+		var entities []tg.MessageEntityClass
+		if addText != "" {
+			if ent, clean := parseTextURL(addText, utf16Len(baseText)); ent != nil {
+				// Используем очищенный текст и сохраняем сущность ссылки
+				editText = baseText + clean
+				entities = append(entities, ent)
+			}
 		}
 
 		// Если требуются изменения, работаем через отложенный пост

--- a/pkg/telegram/channel_duplicate/parse.go
+++ b/pkg/telegram/channel_duplicate/parse.go
@@ -1,0 +1,34 @@
+package channel_duplicate
+
+import (
+	"regexp"
+	"unicode/utf16"
+
+	"github.com/gotd/td/tg"
+)
+
+// mdLinkPattern распознаёт Markdown-ссылку вида [текст](URL).
+var mdLinkPattern = regexp.MustCompile(`\[(.+?)\]\((https?://[^\s)]+)\)`)
+
+// utf16Len возвращает длину строки в кодовых единицах UTF-16.
+func utf16Len(s string) int {
+	return len(utf16.Encode([]rune(s)))
+}
+
+// parseTextURL извлекает из текста Markdown-ссылку и формирует сущность Telegram.
+// offset — смещение начала текста в UTF-16 относительно всей строки сообщения.
+func parseTextURL(text string, offset int) (*tg.MessageEntityTextURL, string) {
+	match := mdLinkPattern.FindStringSubmatch(text)
+	if len(match) != 3 {
+		// Возвращаем исходный текст, если ссылка не распознана
+		return nil, text
+	}
+	label := match[1]
+	url := match[2]
+	ent := &tg.MessageEntityTextURL{
+		Offset: offset,
+		Length: utf16Len(label),
+		URL:    url,
+	}
+	return ent, label
+}


### PR DESCRIPTION
## Summary
- корректно обрабатываем добавляемый текст с markdown-ссылками
- добавлены функции `utf16Len` и `parseTextURL`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b3e38a0cb88327bc617ee56b0e4437