### PR TITLE
Обработка Markdown-ссылок в ChannelDuplicate

### DIFF
--- a/pkg/telegram/channel_duplicate/parse_test.go
+++ b/pkg/telegram/channel_duplicate/parse_test.go
@@ -2,8 +2,8 @@ package channel_duplicate
 
 import "testing"
 
-// TestParseTextURL проверяет корректность вычисления смещений в UTF-16.
-func TestParseTextURL(t *testing.T) {
+// TestParseTextURLSimple проверяет извлечение ссылки без окружения.
+func TestParseTextURLSimple(t *testing.T) {
 	base := "😀Привет" // emoji занимает две позиции UTF-16
 	add := "[Мир](https://example.com)"
 	ent, clean := parseTextURL(add, utf16Len(base))
@@ -18,5 +18,25 @@ func TestParseTextURL(t *testing.T) {
 	}
 	if clean != "Мир" {
 		t.Errorf("ожидался текст 'Мир', получено %q", clean)
+	}
+}
+
+// TestParseTextURLContext проверяет обработку ссылки внутри произвольного текста.
+func TestParseTextURLContext(t *testing.T) {
+	base := "😀Привет" // emoji занимает две позиции UTF-16
+	add := " переходи в [группу](https://example.com)!"
+	ent, clean := parseTextURL(add, utf16Len(base))
+	if ent == nil {
+		t.Fatalf("сущность не найдена")
+	}
+	prefixLen := utf16Len(" переходи в ")
+	if ent.Offset != utf16Len(base)+prefixLen {
+		t.Errorf("ожидался offset %d, получен %d", utf16Len(base)+prefixLen, ent.Offset)
+	}
+	if ent.Length != utf16Len("группу") {
+		t.Errorf("ожидалась длина %d, получена %d", utf16Len("группу"), ent.Length)
+	}
+	if clean != " переходи в группу!" {
+		t.Errorf("ожидался текст ' переходи в группу!', получено %q", clean)
 	}
 }


### PR DESCRIPTION
## Summary
- корректно обрабатываем Markdown-ссылку в добавляемом тексте поста и сохраняем остальные части строки
- добавлены тесты для простого и сложного случаев извлечения ссылки

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b3e86a42dc83279049ec4b56f696c8