### PR TITLE
Сохранение форматирования постов при дублировании

### DIFF
--- a/pkg/telegram/channel_duplicate/channel_duplicate.go
+++ b/pkg/telegram/channel_duplicate/channel_duplicate.go
@@ -133,14 +133,22 @@ func Connect(ctx context.Context, api *tg.Client, dispatcher *tg.UpdateDispatche
 		}
 
 		// Готовим текст и сущности для редактирования
-		editText := text
-		var entities []tg.MessageEntityClass
+		editText := baseText + addText
+		// Копируем исходные сущности, чтобы не изменять оригинал
+		entities := cloneEntities(msg.Entities)
+		// Корректируем смещения сущностей после удаления фрагмента
+		if info.remove != nil && *info.remove != "" {
+			entities = adjustEntitiesAfterRemoval(entities, msg.Message, *info.remove)
+		}
+		// Обрабатываем добавляемый текст и возможную ссылку в нём
 		if addText != "" {
 			if ent, clean := parseTextURL(addText, utf16Len(baseText)); ent != nil {
 				// Используем очищенный текст и сохраняем сущность ссылки
 				editText = baseText + clean
 				entities = append(entities, ent)
 			}
+		} else {
+			editText = baseText
 		}
 
 		// Если требуются изменения, работаем через отложенный пост

--- a/pkg/telegram/channel_duplicate/entities.go
+++ b/pkg/telegram/channel_duplicate/entities.go
@@ -1,0 +1,71 @@
+package channel_duplicate
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/gotd/td/tg"
+)
+
+// cloneEntities создаёт глубокую копию среза сущностей сообщения.
+func cloneEntities(src []tg.MessageEntityClass) []tg.MessageEntityClass {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]tg.MessageEntityClass, len(src))
+	for i, e := range src {
+		v := reflect.New(reflect.TypeOf(e).Elem())
+		v.Elem().Set(reflect.ValueOf(e).Elem())
+		dst[i] = v.Interface().(tg.MessageEntityClass)
+	}
+	return dst
+}
+
+// adjustEntitiesAfterRemoval сдвигает смещения сущностей после удаления фрагмента текста.
+// Предполагается, что удаляемый фрагмент не содержит собственного форматирования.
+func adjustEntitiesAfterRemoval(entities []tg.MessageEntityClass, original, remove string) []tg.MessageEntityClass {
+	if remove == "" || len(entities) == 0 {
+		return entities
+	}
+	remUTF := utf16Len(remove)
+	totalShift := 0
+	searchFrom := 0
+	res := entities
+	for {
+		idx := strings.Index(original[searchFrom:], remove)
+		if idx == -1 {
+			break
+		}
+		start := searchFrom + idx
+		offsetUTF := utf16Len(original[:start]) - totalShift
+		tmp := make([]tg.MessageEntityClass, 0, len(res))
+		for _, ent := range res {
+			off, length := getOffsetLength(ent)
+			switch {
+			case off >= offsetUTF+remUTF:
+				setOffsetLength(ent, off-remUTF, length)
+				tmp = append(tmp, ent)
+			case off+length <= offsetUTF:
+				tmp = append(tmp, ent)
+				// сущность пересекает удалённый фрагмент — пропускаем
+			}
+		}
+		res = tmp
+		searchFrom = start + len(remove)
+		totalShift += remUTF
+	}
+	return res
+}
+
+// getOffsetLength возвращает смещение и длину сущности.
+func getOffsetLength(ent tg.MessageEntityClass) (int, int) {
+	v := reflect.ValueOf(ent).Elem()
+	return int(v.FieldByName("Offset").Int()), int(v.FieldByName("Length").Int())
+}
+
+// setOffsetLength задаёт смещение и длину сущности.
+func setOffsetLength(ent tg.MessageEntityClass, off, length int) {
+	v := reflect.ValueOf(ent).Elem()
+	v.FieldByName("Offset").SetInt(int64(off))
+	v.FieldByName("Length").SetInt(int64(length))
+}

--- a/pkg/telegram/channel_duplicate/entities_test.go
+++ b/pkg/telegram/channel_duplicate/entities_test.go
@@ -1,0 +1,38 @@
+package channel_duplicate
+
+import (
+	"testing"
+
+	"github.com/gotd/td/tg"
+)
+
+// TestAdjustEntitiesAfterRemoval проверяет корректное смещение форматирования после удаления текста.
+func TestAdjustEntitiesAfterRemoval(t *testing.T) {
+	text := "Удалить: жирный текст"
+	remove := "Удалить: "
+	bold := &tg.MessageEntityBold{
+		Offset: utf16Len("Удалить: "),
+		Length: utf16Len("жирный"),
+	}
+	ents := []tg.MessageEntityClass{bold}
+
+	cloned := cloneEntities(ents)
+	adjusted := adjustEntitiesAfterRemoval(cloned, text, remove)
+
+	if bold.Offset != utf16Len("Удалить: ") {
+		t.Fatalf("исходная сущность изменена")
+	}
+	if len(adjusted) != 1 {
+		t.Fatalf("ожидалось 1 сущность, получено %d", len(adjusted))
+	}
+	b, ok := adjusted[0].(*tg.MessageEntityBold)
+	if !ok {
+		t.Fatalf("ожидался тип MessageEntityBold")
+	}
+	if b.Offset != 0 {
+		t.Fatalf("ожидался offset 0, получено %d", b.Offset)
+	}
+	if b.Length != utf16Len("жирный") {
+		t.Fatalf("ожидалась длина %d, получено %d", utf16Len("жирный"), b.Length)
+	}
+}


### PR DESCRIPTION
## Summary
- сохраняем форматирование сообщений при добавлении/удалении текста
- корректируем смещения сущностей и копируем форматирование
- добавлен юнит‑тест на корректировку сущностей

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b3eb9299d48327b42dd556e7fa4ebf