### PR TITLE
Использование уведомлений PostgreSQL для обновления дубликатов каналов

### DIFF
--- a/migrations/2025-09-01-1032_channel_duplicate_notify_trigger.sql
+++ b/migrations/2025-09-01-1032_channel_duplicate_notify_trigger.sql
@@ -1,0 +1,12 @@
+-- Создаём функцию и триггер для уведомления об изменениях в channel_duplicate
+CREATE OR REPLACE FUNCTION notify_channel_duplicate() RETURNS trigger AS $$
+BEGIN
+    -- Отправляем ID записи в канал уведомлений
+    PERFORM pg_notify('channel_duplicate_changed', NEW.id::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER channel_duplicate_notify_trg
+AFTER INSERT OR UPDATE ON channel_duplicate
+FOR EACH ROW EXECUTE FUNCTION notify_channel_duplicate();


### PR DESCRIPTION
## Summary
- слушатель PostgreSQL обновляет карту каналов без перезапуска сервера
- общий метод чтения ChannelDuplicate и выборка записи по ID
- добавлен триггер с pg_notify для таблицы channel_duplicate

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b5760352f08327a048f63abdcb4cd8