### PR TITLE
Удаление поля days_ago

### DIFF
--- a/migrations/2025-09-02-1300_remove_days_ago_channel_duplicate.sql
+++ b/migrations/2025-09-02-1300_remove_days_ago_channel_duplicate.sql
@@ -1,0 +1,3 @@
+-- Удаляет поле days_ago из таблицы channel_duplicate
+ALTER TABLE channel_duplicate
+    DROP COLUMN days_ago;

--- a/models/channel_duplicate.go
+++ b/models/channel_duplicate.go
@@ -21,5 +21,4 @@ type ChannelDuplicate struct {
 	PostTextAdd      *string         `json:"post_text_add"`      // Текст для добавления; ссылки: [текст](url)
 	PostSkip         json.RawMessage `json:"post_skip"`          // Условия пропуска: {"text":[], "url":[]}
 	LastPostID       *int            `json:"last_post_id"`       // ID последнего пересланного поста
-	DaysAgo          *int            `json:"days_ago"`           // Количество дней; NULL если не задано
 }

--- a/pkg/storage/channel_duplicate.go
+++ b/pkg/storage/channel_duplicate.go
@@ -20,9 +20,9 @@ func scanChannelDuplicateOrder(rs rowScanner) (ChannelDuplicateOrder, error) {
 	var (
 		donorTGID, postRemove, postAdd, orderTGID sql.NullString
 		postSkip                                  []byte // JSON с условиями пропуска постов
-		lastPost, daysAgo                         sql.NullInt64
+		lastPost                                  sql.NullInt64
 	)
-	if err := rs.Scan(&cd.ID, &cd.OrderID, &cd.URLChannelDonor, &donorTGID, &postRemove, &postAdd, &postSkip, &lastPost, &daysAgo, &cd.OrderURL, &orderTGID); err != nil {
+	if err := rs.Scan(&cd.ID, &cd.OrderID, &cd.URLChannelDonor, &donorTGID, &postRemove, &postAdd, &postSkip, &lastPost, &cd.OrderURL, &orderTGID); err != nil {
 		return cd, err
 	}
 	if donorTGID.Valid {
@@ -38,10 +38,6 @@ func scanChannelDuplicateOrder(rs rowScanner) (ChannelDuplicateOrder, error) {
 	if lastPost.Valid {
 		v := int(lastPost.Int64)
 		cd.LastPostID = &v
-	}
-	if daysAgo.Valid {
-		v := int(daysAgo.Int64)
-		cd.DaysAgo = &v
 	}
 	if orderTGID.Valid {
 		cd.OrderChannelTGID = &orderTGID.String
@@ -59,7 +55,7 @@ type ChannelDuplicateOrder struct {
 // GetChannelDuplicates возвращает список каналов-источников и связанные с ними заказы.
 func (db *DB) GetChannelDuplicates() ([]ChannelDuplicateOrder, error) {
 	rows, err := db.Conn.Query(`
-                SELECT cd.id, cd.order_id, cd.url_channel_donor, cd.channel_donor_tgid, cd.post_text_remove, cd.post_text_add, cd.post_skip, cd.last_post_id, cd.days_ago,
+                SELECT cd.id, cd.order_id, cd.url_channel_donor, cd.channel_donor_tgid, cd.post_text_remove, cd.post_text_add, cd.post_skip, cd.last_post_id,
                        o.url_default, o.channel_tgid
                 FROM channel_duplicate cd
                 JOIN orders o ON cd.order_id = o.id
@@ -86,7 +82,7 @@ func (db *DB) GetChannelDuplicates() ([]ChannelDuplicateOrder, error) {
 // GetChannelDuplicateOrderByID возвращает запись дублирования с привязанным заказом по её ID.
 func (db *DB) GetChannelDuplicateOrderByID(id int) (*ChannelDuplicateOrder, error) {
 	row := db.Conn.QueryRow(`
-                SELECT cd.id, cd.order_id, cd.url_channel_donor, cd.channel_donor_tgid, cd.post_text_remove, cd.post_text_add, cd.post_skip, cd.last_post_id, cd.days_ago,
+                SELECT cd.id, cd.order_id, cd.url_channel_donor, cd.channel_donor_tgid, cd.post_text_remove, cd.post_text_add, cd.post_skip, cd.last_post_id,
                        o.url_default, o.channel_tgid
                 FROM channel_duplicate cd
                 JOIN orders o ON cd.order_id = o.id


### PR DESCRIPTION
## Изменения
- удалена логика поля `days_ago` из моделей и хранилища
- добавлена миграция для удаления столбца `days_ago` из таблицы `channel_duplicate`

## Тесты
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6951ede608327861404a9a900d64a