### PR TITLE
Добавлено поле post_count_day в ChannelDuplicate

### DIFF
--- a/migrations/2025-09-02-1400_add_post_count_day_channel_duplicate.sql
+++ b/migrations/2025-09-02-1400_add_post_count_day_channel_duplicate.sql
@@ -1,0 +1,4 @@
+-- Добавляет поле post_count_day в таблицу channel_duplicate
+-- Поле хранит число постов в день; значение по умолчанию NULL
+ALTER TABLE channel_duplicate
+    ADD COLUMN post_count_day integer;

--- a/models/channel_duplicate.go
+++ b/models/channel_duplicate.go
@@ -21,4 +21,5 @@ type ChannelDuplicate struct {
 	PostTextAdd      *string         `json:"post_text_add"`      // Текст для добавления; ссылки: [текст](url)
 	PostSkip         json.RawMessage `json:"post_skip"`          // Условия пропуска: {"text":[], "url":[]}
 	LastPostID       *int            `json:"last_post_id"`       // ID последнего пересланного поста
+	PostCountDay     *int            `json:"post_count_day"`     // Число публикаций в день
 }

--- a/pkg/storage/channel_duplicate.go
+++ b/pkg/storage/channel_duplicate.go
@@ -20,9 +20,9 @@ func scanChannelDuplicateOrder(rs rowScanner) (ChannelDuplicateOrder, error) {
 	var (
 		donorTGID, postRemove, postAdd, orderTGID sql.NullString
 		postSkip                                  []byte // JSON с условиями пропуска постов
-		lastPost                                  sql.NullInt64
+		lastPost, postCountDay                    sql.NullInt64
 	)
-	if err := rs.Scan(&cd.ID, &cd.OrderID, &cd.URLChannelDonor, &donorTGID, &postRemove, &postAdd, &postSkip, &lastPost, &cd.OrderURL, &orderTGID); err != nil {
+	if err := rs.Scan(&cd.ID, &cd.OrderID, &cd.URLChannelDonor, &donorTGID, &postRemove, &postAdd, &postSkip, &lastPost, &postCountDay, &cd.OrderURL, &orderTGID); err != nil {
 		return cd, err
 	}
 	if donorTGID.Valid {
@@ -38,6 +38,10 @@ func scanChannelDuplicateOrder(rs rowScanner) (ChannelDuplicateOrder, error) {
 	if lastPost.Valid {
 		v := int(lastPost.Int64)
 		cd.LastPostID = &v
+	}
+	if postCountDay.Valid {
+		v := int(postCountDay.Int64)
+		cd.PostCountDay = &v
 	}
 	if orderTGID.Valid {
 		cd.OrderChannelTGID = &orderTGID.String
@@ -55,7 +59,7 @@ type ChannelDuplicateOrder struct {
 // GetChannelDuplicates возвращает список каналов-источников и связанные с ними заказы.
 func (db *DB) GetChannelDuplicates() ([]ChannelDuplicateOrder, error) {
 	rows, err := db.Conn.Query(`
-                SELECT cd.id, cd.order_id, cd.url_channel_donor, cd.channel_donor_tgid, cd.post_text_remove, cd.post_text_add, cd.post_skip, cd.last_post_id,
+                SELECT cd.id, cd.order_id, cd.url_channel_donor, cd.channel_donor_tgid, cd.post_text_remove, cd.post_text_add, cd.post_skip, cd.last_post_id, cd.post_count_day,
                        o.url_default, o.channel_tgid
                 FROM channel_duplicate cd
                 JOIN orders o ON cd.order_id = o.id
@@ -82,7 +86,7 @@ func (db *DB) GetChannelDuplicates() ([]ChannelDuplicateOrder, error) {
 // GetChannelDuplicateOrderByID возвращает запись дублирования с привязанным заказом по её ID.
 func (db *DB) GetChannelDuplicateOrderByID(id int) (*ChannelDuplicateOrder, error) {
 	row := db.Conn.QueryRow(`
-                SELECT cd.id, cd.order_id, cd.url_channel_donor, cd.channel_donor_tgid, cd.post_text_remove, cd.post_text_add, cd.post_skip, cd.last_post_id,
+                SELECT cd.id, cd.order_id, cd.url_channel_donor, cd.channel_donor_tgid, cd.post_text_remove, cd.post_text_add, cd.post_skip, cd.last_post_id, cd.post_count_day,
                        o.url_default, o.channel_tgid
                 FROM channel_duplicate cd
                 JOIN orders o ON cd.order_id = o.id


### PR DESCRIPTION
## Summary
- добавить миграцию с полем `post_count_day` для `channel_duplicate`
- учесть новое поле в модели и выборках БД

## Testing
- `go test ./...` *(прервано: команда не дала вывода)*

------
https://chatgpt.com/codex/tasks/task_e_68b697877a80832784187e181405fb99