### PR TITLE
fix scanning of post_count_day for channel duplicates

### DIFF
--- a/pkg/storage/channel_duplicate.go
+++ b/pkg/storage/channel_duplicate.go
@@ -24,7 +24,7 @@ func scanChannelDuplicateOrder(rs rowScanner) (ChannelDuplicateOrder, error) {
 		lastPost                                  sql.NullInt64
 		postCountDay                              pq.StringArray
 	)
-	if err := rs.Scan(&cd.ID, &cd.OrderID, &cd.URLChannelDonor, &donorTGID, &postRemove, &postAdd, &postSkip, &lastPost, pq.Array(&postCountDay), &cd.OrderURL, &orderTGID); err != nil {
+	if err := rs.Scan(&cd.ID, &cd.OrderID, &cd.URLChannelDonor, &donorTGID, &postRemove, &postAdd, &postSkip, &lastPost, &postCountDay, &cd.OrderURL, &orderTGID); err != nil {
 		return cd, err
 	}
 	if donorTGID.Valid {


### PR DESCRIPTION
## Summary
- fix retrieval of PostCountDay by scanning directly into pq.StringArray

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b853e83d8083338aeddb741d45aaac