### PR TITLE
Добавлена обработка расписания публикаций

### DIFF
--- a/internal/module/channel_duplicate_times.go
+++ b/internal/module/channel_duplicate_times.go
@@ -1,0 +1,43 @@
+package module
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"atg_go/internal/httputil"
+	"github.com/gin-gonic/gin"
+	"github.com/lib/pq"
+)
+
+// UpdateChannelDuplicateTimes обрабатывает POST /module/channel_duplicate/:id/post_count_day.
+// Ожидает JSON-массив времени в формате HH:MM и сохраняет его в БД.
+func (h *Handler) UpdateChannelDuplicateTimes(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		httputil.RespondError(c, http.StatusBadRequest, "некорректный id")
+		return
+	}
+
+	var times []string
+	if err := c.ShouldBindJSON(&times); err != nil {
+		httputil.RespondError(c, http.StatusBadRequest, "ожидается массив строк HH:MM")
+		return
+	}
+
+	for _, t := range times {
+		if _, err := time.Parse("15:04", t); err != nil {
+			httputil.RespondError(c, http.StatusBadRequest, "некорректный формат времени: "+t)
+			return
+		}
+	}
+
+	if err := h.DB.UpdateChannelDuplicateTimes(id, pq.StringArray(times)); err != nil {
+		log.Printf("[ERROR] обновление post_count_day для channel_duplicate %d: %v", id, err)
+		httputil.RespondError(c, http.StatusInternalServerError, "db error")
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "updated"})
+}

--- a/internal/module/routes.go
+++ b/internal/module/routes.go
@@ -15,6 +15,7 @@ func SetupRoutes(r *gin.RouterGroup, db *storage.DB) {
 	r.POST("/dispatcher_activity/cancel_all", handler.CancelAllDispatcherActivity)
 	r.POST("/unsubscribe", handler.Unsubscribe)
 	r.POST("/order/link_updat", handler.OrderLinkUpdate)
+	r.POST("/channel_duplicate/:id/post_count_day", handler.UpdateChannelDuplicateTimes)
 	authcheck.SetupRoutes(r.Group("/account_auth_check"), db)
 	activesessions.SetupRoutes(r.Group("/active_sessions_disconnect"), db)
 }

--- a/pkg/storage/channel_duplicate.go
+++ b/pkg/storage/channel_duplicate.go
@@ -152,3 +152,12 @@ func (db *DB) TrySetLastPostID(id int, postID int) (updated bool, remove *string
 	}
 	return true, remove, add, nil
 }
+
+// UpdateChannelDuplicateTimes обновляет расписание публикаций (post_count_day) для записи channel_duplicate.
+func (db *DB) UpdateChannelDuplicateTimes(id int, times pq.StringArray) error {
+	_, err := db.Conn.Exec(
+		`UPDATE channel_duplicate SET post_count_day = $1 WHERE id = $2`,
+		pq.Array(times), id,
+	)
+	return err
+}


### PR DESCRIPTION
## Summary
- добавлен API-метод для сохранения массива времени `post_count_day`
- реализовано сохранение расписания как `pq.StringArray` в таблице `channel_duplicate`

## Testing
- `go test ./... -run Test -count=1 -timeout 30s` *(завис, процесс прерван)*

------
https://chatgpt.com/codex/tasks/task_e_68b88d507c848333a15be3dee963443d