### PR TITLE
Настраиваемые реакции для дублируемых постов

### DIFF
--- a/migrations/2025-09-02-1600_add_post_reactions_channel_duplicate.sql
+++ b/migrations/2025-09-02-1600_add_post_reactions_channel_duplicate.sql
@@ -1,0 +1,4 @@
+-- Добавляет post_reactions для выбора реакции к посту
+-- Хранит список эмодзи или NULL
+ALTER TABLE channel_duplicate
+    ADD COLUMN post_reactions TEXT[];

--- a/models/channel_duplicate.go
+++ b/models/channel_duplicate.go
@@ -26,4 +26,5 @@ type ChannelDuplicate struct {
 	PostSkip         json.RawMessage `json:"post_skip"`          // Условия пропуска: {"text":[], "url":[]}
 	LastPostID       *int            `json:"last_post_id"`       // ID последнего пересланного поста
 	PostCountDay     pq.StringArray  `json:"post_count_day"`     // Времена публикаций в формате HH:MM:SS
+	PostReactions    pq.StringArray  `json:"post_reactions"`     // Перечень реакций; NULL — стандартный выбор
 }

--- a/pkg/telegram/module/monitoring/view_scheduler.go
+++ b/pkg/telegram/module/monitoring/view_scheduler.go
@@ -101,7 +101,7 @@ func schedulePostViews(db *storage.DB, post models.ChannelPost, theory models.Ch
 						log.Printf("[MONITORING] обновление факта просмотров: %v", err)
 					}
 					if doReact {
-						if err := postaction.SendReaction(db, a, post.PostURL); err != nil {
+						if err := postaction.SendReaction(db, a, post.OrderID, post.PostURL); err != nil {
 							log.Printf("[MONITORING] реакция не выполнена: %v", err)
 						} else if err := db.IncrementChannelPostFact(theoryID, "reaction_24hour_fact"); err != nil {
 							log.Printf("[MONITORING] обновление факта реакций: %v", err)


### PR DESCRIPTION
## Summary
- добавлено поле `post_reactions` в `channel_duplicate`
- реакция к посту может выбираться из заданного списка
- расширено хранилище для чтения реакций по заказу

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8a586d20c8333857e1aab0486a698