### PR TITLE
feat: перенос реакций постов в заказ

### DIFF
--- a/migrations/2025-09-02-1700_move_post_reactions_to_orders.sql
+++ b/migrations/2025-09-02-1700_move_post_reactions_to_orders.sql
@@ -1,0 +1,19 @@
+-- Переносит post_reactions из channel_duplicate в orders
+-- Добавляет поле post_reactions в таблицу orders и удаляет его из channel_duplicate
+ALTER TABLE orders
+    ADD COLUMN post_reactions TEXT[];
+
+-- Копируем существующие данные реакций из channel_duplicate в orders
+UPDATE orders o
+SET post_reactions = cd.post_reactions
+FROM (
+    SELECT DISTINCT ON (order_id) order_id, post_reactions
+    FROM channel_duplicate
+    WHERE post_reactions IS NOT NULL
+    ORDER BY order_id
+) cd
+WHERE o.id = cd.order_id;
+
+-- Удаляем поле из channel_duplicate
+ALTER TABLE channel_duplicate
+    DROP COLUMN post_reactions;

--- a/models/channel_duplicate.go
+++ b/models/channel_duplicate.go
@@ -26,5 +26,4 @@ type ChannelDuplicate struct {
 	PostSkip         json.RawMessage `json:"post_skip"`          // Условия пропуска: {"text":[], "url":[]}
 	LastPostID       *int            `json:"last_post_id"`       // ID последнего пересланного поста
 	PostCountDay     pq.StringArray  `json:"post_count_day"`     // Времена публикаций в формате HH:MM:SS
-	PostReactions    pq.StringArray  `json:"post_reactions"`     // Перечень реакций, задаётся в виде {"😀","😂"}; NULL — стандартный выбор
 }

--- a/models/order.go
+++ b/models/order.go
@@ -26,6 +26,7 @@ type Order struct {
 	AccountsNumberTheory int            `json:"accounts_number_theory"`
 	AccountsNumberFact   int            `json:"accounts_number_fact"`
 	SubsActiveCount      *int           `json:"subs_active_count"` // Сколько аккаунтов должны активничать на канале; NULL, если не задано
+	PostReactions        pq.StringArray `json:"post_reactions"`    // Перечень реакций, задаётся в виде {"😀","😂"}; NULL — стандартный выбор
 	Gender               pq.StringArray `json:"gender"`            // Пол(ы) аккаунтов для заказа
 	DateTime             time.Time      `json:"date_time"`
 }

--- a/pkg/storage/channel_duplicate.go
+++ b/pkg/storage/channel_duplicate.go
@@ -22,9 +22,9 @@ func scanChannelDuplicateOrder(rs rowScanner) (ChannelDuplicateOrder, error) {
 		donorTGID, postRemove, postAdd, orderTGID sql.NullString
 		postSkip                                  []byte // JSON с условиями пропуска постов
 		lastPost                                  sql.NullInt64
-		postCountDay, postReactions               pq.StringArray
+		postCountDay                              pq.StringArray
 	)
-	if err := rs.Scan(&cd.ID, &cd.OrderID, &cd.URLChannelDonor, &donorTGID, &postRemove, &postAdd, &postSkip, &lastPost, &postCountDay, &postReactions, &cd.OrderURL, &orderTGID); err != nil {
+	if err := rs.Scan(&cd.ID, &cd.OrderID, &cd.URLChannelDonor, &donorTGID, &postRemove, &postAdd, &postSkip, &lastPost, &postCountDay, &cd.OrderURL, &orderTGID); err != nil {
 		return cd, err
 	}
 	if donorTGID.Valid {
@@ -42,7 +42,6 @@ func scanChannelDuplicateOrder(rs rowScanner) (ChannelDuplicateOrder, error) {
 		cd.LastPostID = &v
 	}
 	cd.PostCountDay = postCountDay
-	cd.PostReactions = postReactions
 	if orderTGID.Valid {
 		cd.OrderChannelTGID = &orderTGID.String
 	}
@@ -59,7 +58,7 @@ type ChannelDuplicateOrder struct {
 // GetChannelDuplicates возвращает список каналов-источников и связанные с ними заказы.
 func (db *DB) GetChannelDuplicates() ([]ChannelDuplicateOrder, error) {
 	rows, err := db.Conn.Query(`
-                SELECT cd.id, cd.order_id, cd.url_channel_donor, cd.channel_donor_tgid, cd.post_text_remove, cd.post_text_add, cd.post_skip, cd.last_post_id, cd.post_count_day, cd.post_reactions,
+                SELECT cd.id, cd.order_id, cd.url_channel_donor, cd.channel_donor_tgid, cd.post_text_remove, cd.post_text_add, cd.post_skip, cd.last_post_id, cd.post_count_day,
                        o.url_default, o.channel_tgid
                 FROM channel_duplicate cd
                 JOIN orders o ON cd.order_id = o.id
@@ -86,7 +85,7 @@ func (db *DB) GetChannelDuplicates() ([]ChannelDuplicateOrder, error) {
 // GetChannelDuplicateOrderByID возвращает запись дублирования с привязанным заказом по её ID.
 func (db *DB) GetChannelDuplicateOrderByID(id int) (*ChannelDuplicateOrder, error) {
 	row := db.Conn.QueryRow(`
-                SELECT cd.id, cd.order_id, cd.url_channel_donor, cd.channel_donor_tgid, cd.post_text_remove, cd.post_text_add, cd.post_skip, cd.last_post_id, cd.post_count_day, cd.post_reactions,
+                SELECT cd.id, cd.order_id, cd.url_channel_donor, cd.channel_donor_tgid, cd.post_text_remove, cd.post_text_add, cd.post_skip, cd.last_post_id, cd.post_count_day,
                        o.url_default, o.channel_tgid
                 FROM channel_duplicate cd
                 JOIN orders o ON cd.order_id = o.id
@@ -169,7 +168,7 @@ func (db *DB) GetPostReactionsForOrder(orderID int) (pq.StringArray, error) {
 	var raw sql.NullString
 	// Приводим массив к тексту, чтобы получить строку вида {"😀","😢"}
 	err := db.Conn.QueryRow(
-		`SELECT post_reactions::text FROM channel_duplicate WHERE order_id = $1 LIMIT 1`,
+		`SELECT post_reactions::text FROM orders WHERE id = $1`,
 		orderID,
 	).Scan(&raw)
 	if err == sql.ErrNoRows || !raw.Valid {

--- a/pkg/telegram/post/reaction.go
+++ b/pkg/telegram/post/reaction.go
@@ -17,7 +17,7 @@ import (
 )
 
 // SendReaction добавляет реакцию к посту канала по ссылке postURL.
-// orderID нужен для выбора предопределённых реакций из channel_duplicate.
+// orderID нужен для выбора предопределённых реакций из заказа (orders).
 // Функция не фиксирует активность аккаунта.
 func SendReaction(db *storage.DB, acc models.Account, orderID int, postURL string) error {
 	// Блокируем аккаунт на время операции, чтобы избежать параллельного использования
@@ -95,7 +95,7 @@ func SendReaction(db *storage.DB, acc models.Account, orderID int, postURL strin
 			}
 		}
 
-		// Получаем список реакций из channel_duplicate, если он задан
+		// Получаем список реакций из заказа, если он задан
 		reactions, err := db.GetPostReactionsForOrder(orderID)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary
- перенос post_reactions из channel_duplicate в orders
- обновление моделей и хранения реакций для заказов
- корректировка логики отправки реакций

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8afe965748333851b15f797ef9ec9