### PR TITLE
Добавлена таблица category_channels_delete

### DIFF
--- a/migrations/2025-09-02-1800_create_category_channels_delete.sql
+++ b/migrations/2025-09-02-1800_create_category_channels_delete.sql
@@ -1,0 +1,10 @@
+-- Создаёт таблицу для хранения ссылок удалённых каналов и причин их удаления
+CREATE TABLE category_channels_delete (
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- Уникальный идентификатор записи
+    channel_url TEXT NOT NULL,                           -- Ссылка на канал
+    reason TEXT NOT NULL CHECK (reason IN (
+        'не существует канала по username',              -- Канал с таким username не найден
+        'закрытый канал',                                -- Закрытый канал
+        'недоступно обсуждение'                          -- Включены ограничения на обсуждение
+    )) -- Причина удаления с ограничением значений
+);

--- a/models/category_channels_delete.go
+++ b/models/category_channels_delete.go
@@ -1,0 +1,11 @@
+package models
+
+// CategoryChannelsDelete хранит ссылку удалённого канала и причину удаления
+// Комментарии пишутся на русском языке по требованию пользователя
+// reason должен принимать одно из заранее определённых значений
+// "не существует канала по username", "закрытый канал", "недоступно обсуждение"
+type CategoryChannelsDelete struct {
+	ID         int    `json:"id"`          // Уникальный идентификатор записи
+	ChannelURL string `json:"channel_url"` // Ссылка на канал
+	Reason     string `json:"reason"`      // Причина удаления
+}


### PR DESCRIPTION
## Summary
- добавить миграцию для таблицы `category_channels_delete`
- описать модель `CategoryChannelsDelete` на Go

## Testing
- `go test ./models`
- `go test ./...` *(зависло, остановлено вручную)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b658fd44833383741b1c194e17d9