### PR TITLE
Фиксация недоступных каналов

### DIFF
--- a/migrations/2025-09-06-1200_update_category_channels_delete_reasons.sql
+++ b/migrations/2025-09-06-1200_update_category_channels_delete_reasons.sql
@@ -1,0 +1,9 @@
+-- Обновляет допустимые значения причины удаления канала
+ALTER TABLE category_channels_delete
+    DROP CONSTRAINT IF EXISTS category_channels_delete_reason_check,
+    ADD CONSTRAINT category_channels_delete_reason_check CHECK (reason IN (
+        'не существует канала по ссылке',
+        'канал закрыт',
+        'недоступно обсуждение'
+    ));
+

--- a/models/category_channels_delete.go
+++ b/models/category_channels_delete.go
@@ -1,11 +1,16 @@
 package models
 
-// CategoryChannelsDelete хранит ссылку удалённого канала и причину удаления
-// Комментарии пишутся на русском языке по требованию пользователя
-// reason должен принимать одно из заранее определённых значений
-// "не существует канала по username", "закрытый канал", "недоступно обсуждение"
+// CategoryChannelsDelete хранит ссылку удалённого канала и причину удаления.
+// reason должен принимать одно из значений констант ниже.
 type CategoryChannelsDelete struct {
 	ID         int    `json:"id"`          // Уникальный идентификатор записи
 	ChannelURL string `json:"channel_url"` // Ссылка на канал
 	Reason     string `json:"reason"`      // Причина удаления
 }
+
+// Значения поля Reason.
+const (
+	ReasonChannelMissing   = "не существует канала по ссылке" // Канал не найден по URL
+	ReasonChannelClosed    = "канал закрыт"                   // Канал закрыт для просмотра
+	ReasonDiscussionClosed = "недоступно обсуждение"          // У канала отключены обсуждения
+)

--- a/pkg/storage/category_channels_delete.go
+++ b/pkg/storage/category_channels_delete.go
@@ -1,0 +1,10 @@
+package storage
+
+// SaveCategoryChannelDelete сохраняет ссылку канала и причину его недоступности.
+func (db *DB) SaveCategoryChannelDelete(url, reason string) error {
+	_, err := db.Conn.Exec(
+		`INSERT INTO category_channels_delete (channel_url, reason) VALUES ($1, $2)`,
+		url, reason,
+	)
+	return err
+}


### PR DESCRIPTION
## Summary
- сохранить ссылку и причину в CategoryChannelsDelete при недоступности канала или обсуждения
- обновить список допустимых причин удаления канала

## Testing
- `go test ./...` *(fails: github.com/stretchr/testify@v1.3.0: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bae6d25c8333b563630c379274d3