### PR TITLE
Исключение удалённых каналов при выборе активности

### DIFF
--- a/pkg/storage/comment_test.go
+++ b/pkg/storage/comment_test.go
@@ -21,6 +21,10 @@ type commentTestRows struct {
 
 type commentDummyResult struct{}
 
+// commentBanned имитирует содержимое таблицы category_channels_delete.
+// Заполняется в тестах перед обращением к базе.
+var commentBanned []string
+
 func (commentTestDriver) Open(name string) (driver.Conn, error) { return &commentTestConn{}, nil }
 
 func (c *commentTestConn) Prepare(query string) (driver.Stmt, error) {
@@ -37,6 +41,13 @@ func (c *commentTestConn) QueryContext(ctx context.Context, query string, args [
 	case 1:
 		c.step++
 		return &commentTestRows{columns: []string{"id", "name", "urls"}, data: [][]driver.Value{{int64(1), "cat", []byte("[\"url\"]")}}}, nil
+	case 2:
+		c.step++
+		data := make([][]driver.Value, len(commentBanned))
+		for i, u := range commentBanned {
+			data[i] = []driver.Value{u}
+		}
+		return &commentTestRows{columns: []string{"channel_url"}, data: data}, nil
 	default:
 		return nil, errors.New("unexpected query")
 	}
@@ -63,6 +74,8 @@ func (r *commentTestRows) Next(dest []driver.Value) error {
 func init() { sql.Register("commentDummy", commentTestDriver{}) }
 
 func TestPickRandomChannelWithoutCategories(t *testing.T) {
+	commentBanned = nil
+
 	db, err := sql.Open("commentDummy", "")
 	if err != nil {
 		t.Fatalf("не удалось открыть мок БД: %v", err)
@@ -76,5 +89,21 @@ func TestPickRandomChannelWithoutCategories(t *testing.T) {
 	}
 	if url != "url" {
 		t.Fatalf("неверный URL канала: %s", url)
+	}
+}
+
+func TestPickRandomChannelExcluded(t *testing.T) {
+	commentBanned = []string{"url"}
+
+	db, err := sql.Open("commentDummy", "")
+	if err != nil {
+		t.Fatalf("не удалось открыть мок БД: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	cdb := &CommentDB{Conn: db}
+	_, err = PickRandomChannel(cdb, 1)
+	if !errors.Is(err, ErrNoChannel) {
+		t.Fatalf("ожидалась ошибка ErrNoChannel, получена: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- исключить каналы из `category_channels_delete` при выборе URL для активности
- покрыть логику тестами

## Testing
- `go test -v ./pkg/storage -run TestPickRandomChannel -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b8c46ab9908333b8515f0f04f57c2e