### PR TITLE
feat: generate category channels

### DIFF
--- a/internal/generation_category_channels/handler.go
+++ b/internal/generation_category_channels/handler.go
@@ -1,0 +1,125 @@
+package generation_category_channels
+
+import (
+	"context"
+	"log"
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+
+	"atg_go/internal/httputil"
+	"atg_go/models"
+	"atg_go/pkg/storage"
+	"atg_go/pkg/telegram"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler обрабатывает запросы генерации подборки каналов.
+type Handler struct {
+	DB *storage.DB
+}
+
+// NewHandler создаёт новый экземпляр обработчика.
+func NewHandler(db *storage.DB) *Handler {
+	return &Handler{DB: db}
+}
+
+type request struct {
+	NameCategory     string   `json:"name_category" binding:"required"`
+	InputChannels    []string `json:"input_channels" binding:"required"`
+	ResultCountLinks int      `json:"result_count_links" binding:"required"`
+}
+
+// GenerateCategory обрабатывает POST-запрос и формирует новую категорию каналов.
+func (h *Handler) GenerateCategory(c *gin.Context) {
+	var req request
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.RespondError(c, http.StatusBadRequest, "invalid request format")
+		return
+	}
+
+	accounts, err := h.DB.GetMonitoringAccounts()
+	if err != nil {
+		httputil.RespondError(c, http.StatusInternalServerError, "failed to get monitoring accounts")
+		return
+	}
+	if len(accounts) == 0 {
+		httputil.RespondError(c, http.StatusNotFound, "monitoring accounts not found")
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var mu sync.Mutex
+	results := make(map[string]struct{})
+
+	queues := make([][]string, len(accounts))
+	for i, ch := range req.InputChannels {
+		queues[i%len(accounts)] = append(queues[i%len(accounts)], ch)
+	}
+
+	var wg sync.WaitGroup
+	for i, acc := range accounts {
+		queue := append([]string(nil), queues[i]...)
+		wg.Add(1)
+		go func(account models.Account, q []string) {
+			defer wg.Done()
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			processed := make(map[string]struct{})
+			for len(q) > 0 {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				url := q[0]
+				q = q[1:]
+				if _, ok := processed[url]; ok {
+					continue
+				}
+				processed[url] = struct{}{}
+				recs, err := telegram.GetChannelRecommendations(h.DB, account, url)
+				if err != nil {
+					log.Printf("[GENERATION WARN] %v", err)
+					continue
+				}
+				mu.Lock()
+				for _, link := range recs {
+					if _, exists := results[link]; !exists {
+						results[link] = struct{}{}
+						if len(results) >= req.ResultCountLinks {
+							mu.Unlock()
+							cancel()
+							return
+						}
+						q = append(q, link)
+					}
+				}
+				mu.Unlock()
+				time.Sleep(time.Duration(500+r.Intn(1000)) * time.Millisecond)
+			}
+		}(acc, queue)
+	}
+
+	wg.Wait()
+
+	mu.Lock()
+	urls := make([]string, 0, len(results))
+	for url := range results {
+		urls = append(urls, url)
+	}
+	mu.Unlock()
+
+	if _, err := h.DB.CreateCategory(req.NameCategory, urls); err != nil {
+		httputil.RespondError(c, http.StatusInternalServerError, "failed to save category")
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status": "ok",
+		"count":  len(urls),
+	})
+}

--- a/internal/generation_category_channels/routes.go
+++ b/internal/generation_category_channels/routes.go
@@ -1,0 +1,13 @@
+package generation_category_channels
+
+import (
+	"atg_go/pkg/storage"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SetupRoutes регистрирует маршруты генерации подборки каналов.
+func SetupRoutes(r *gin.RouterGroup, db *storage.DB) {
+	handler := NewHandler(db)
+	r.POST("", handler.GenerateCategory)
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"atg_go/internal/auth"
 	"atg_go/internal/comments"
+	genchannels "atg_go/internal/generation_category_channels"
 	"atg_go/internal/middleware"
 	module "atg_go/internal/module"
 	orders "atg_go/internal/order"
@@ -99,6 +100,10 @@ func setupRouter(db *storage.DB, commentDB *storage.CommentDB) *gin.Engine {
 	// Группа роутов для статистики
 	statsGroup := r.Group("/statistics")
 	statistics.SetupRoutes(statsGroup, db)
+
+	// Группа роутов для генерации подборок каналов
+	genGroup := r.Group("/generation_category_channels")
+	genchannels.SetupRoutes(genGroup, db)
 
 	// Health check endpoint
 	r.GET("/health", func(c *gin.Context) {

--- a/pkg/telegram/generation_category_channels.go
+++ b/pkg/telegram/generation_category_channels.go
@@ -1,0 +1,12 @@
+package telegram
+
+import (
+	"atg_go/models"
+	"atg_go/pkg/storage"
+	gcc "atg_go/pkg/telegram/generation_category_channels"
+)
+
+// GetChannelRecommendations делегирует получение похожих каналов подпакету generation_category_channels.
+func GetChannelRecommendations(db *storage.DB, acc models.Account, channelURL string) ([]string, error) {
+	return gcc.GetChannelRecommendations(db, acc, channelURL)
+}

--- a/pkg/telegram/generation_category_channels/generation_category_channels.go
+++ b/pkg/telegram/generation_category_channels/generation_category_channels.go
@@ -1,0 +1,66 @@
+package generation_category_channels
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"atg_go/models"
+	"atg_go/pkg/storage"
+	module "atg_go/pkg/telegram/module"
+	accountmutex "atg_go/pkg/telegram/module/account_mutex"
+
+	"github.com/gotd/td/tg"
+)
+
+// GetChannelRecommendations возвращает список похожих каналов для указанного канала.
+// Работает от имени заданного аккаунта.
+func GetChannelRecommendations(db *storage.DB, acc models.Account, channelURL string) ([]string, error) {
+	if err := accountmutex.LockAccount(acc.ID); err != nil {
+		return nil, err
+	}
+	defer accountmutex.UnlockAccount(acc.ID)
+
+	client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	var result []string
+	err = client.Run(ctx, func(ctx context.Context) error {
+		api := tg.NewClient(client)
+		username, err := module.Modf_ExtractUsername(channelURL)
+		if err != nil {
+			return err
+		}
+		resolved, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: username})
+		if err != nil {
+			return err
+		}
+		ch, err := module.Modf_FindChannel(resolved.GetChats())
+		if err != nil {
+			return err
+		}
+		resp, err := api.ChannelsGetChannelRecommendations(ctx, &tg.ChannelsGetChannelRecommendationsRequest{
+			Channel: &tg.InputChannel{ChannelID: ch.ID, AccessHash: ch.AccessHash},
+		})
+		if err != nil {
+			return err
+		}
+		for _, chat := range resp.GetChats() {
+			if rec, ok := chat.(*tg.Channel); ok {
+				if rec.Username != "" {
+					result = append(result, "https://t.me/"+rec.Username)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("не удалось получить рекомендации: %w", err)
+	}
+	return result, nil
+}


### PR DESCRIPTION
## Summary
- add generation_category_channels endpoint to build channel lists using monitoring accounts
- fetch telegram channel recommendations and save categories

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb1b7eb2d88333a67273e9baaf47fa