### PR TITLE
Handle duplicate channels when generating categories

### DIFF
--- a/migrations/2025-09-07-0000_create_channels.sql
+++ b/migrations/2025-09-07-0000_create_channels.sql
@@ -1,0 +1,5 @@
+-- Таблица каналов для хранения уникальных ссылок.
+CREATE TABLE IF NOT EXISTS channels (
+    url TEXT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- ignore existing records when saving found channels
- add migration for channels table

## Testing
- `go test ./pkg/storage -count=1`
- `go test ./pkg/telegram/... -count=1` *(fails: command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bb450c214c8333bd3c6b1132aaaad3