### PR TITLE
refactor: lock accounts once for recommendations

### DIFF
--- a/pkg/storage/category.go
+++ b/pkg/storage/category.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"database/sql"
 	"encoding/json"
+	"log"
 
 	"atg_go/models"
 
@@ -51,10 +52,12 @@ func (db *DB) CreateCategory(name string, urls []string) (*models.Category, erro
 
 		// Вставляем ссылки; повторения игнорируются за счёт ON CONFLICT.
 		if _, err := db.Conn.Exec(`
-                        INSERT INTO channels (url)
-                        SELECT unnest($1::text[])
-                        ON CONFLICT (url) DO NOTHING
-                `, pq.Array(uniqueURLs)); err != nil {
+                       INSERT INTO channels (url)
+                       SELECT unnest($1::text[])
+                       ON CONFLICT (url) DO NOTHING
+               `, pq.Array(uniqueURLs)); err != nil {
+			// Фиксируем проблему сохранения списка каналов
+			log.Printf("[DB ERROR] вставка каналов %v завершилась ошибкой: %v", uniqueURLs, err)
 			return nil, err
 		}
 	}

--- a/pkg/telegram/generation_category_channels/generation_category_channels.go
+++ b/pkg/telegram/generation_category_channels/generation_category_channels.go
@@ -9,20 +9,16 @@ import (
 	"atg_go/models"
 	"atg_go/pkg/storage"
 	module "atg_go/pkg/telegram/module"
-	accountmutex "atg_go/pkg/telegram/module/account_mutex"
 
 	"github.com/gotd/td/tg"
 )
 
 // GetChannelRecommendations возвращает список похожих каналов для указанного канала.
 // Работает от имени заданного аккаунта.
+// GetChannelRecommendations предполагает, что аккаунт уже заблокирован
+// вызывающей стороной. Это позволяет избежать повторных попыток
+// захвата одного и того же мьютекса при множественных запросах.
 func GetChannelRecommendations(db *storage.DB, acc models.Account, channelURL string) ([]string, error) {
-	if err := accountmutex.LockAccount(acc.ID); err != nil {
-		// Фиксируем проблемы при блокировке аккаунта
-		log.Printf("[GENERATION ERROR] не удалось заблокировать аккаунт %d: %v", acc.ID, err)
-		return nil, err
-	}
-	defer accountmutex.UnlockAccount(acc.ID)
 
 	client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- lock monitoring accounts once at handler level and skip busy ones
- drop internal mutex from GetChannelRecommendations, expecting caller to handle locking
- log channel insert failures for easier diagnostics

## Testing
- `go test ./...` *(fails: no output, process hung)*
- `go build ./...` *(fails: no output, process hung)*

------
https://chatgpt.com/codex/tasks/task_e_68bb54a9e1708333aa260d5f1090ea5d