### PR TITLE
feat: add detailed logging

### DIFF
--- a/pkg/telegram/module/account_mutex/account_mutex.go
+++ b/pkg/telegram/module/account_mutex/account_mutex.go
@@ -7,14 +7,24 @@ import (
 )
 
 var (
-	globalMu     sync.Mutex
-	accountLocks = make(map[int]*sync.Mutex)
+	globalMu       sync.Mutex
+	accountLocks   = make(map[int]*sync.Mutex)
+	lockedAccounts = make(map[int]struct{})
 )
 
+// lockedIDs возвращает список текущих заблокированных аккаунтов.
+// Предполагается, что глобальный мьютекс уже захвачен.
+func lockedIDs() []int {
+	ids := make([]int, 0, len(lockedAccounts))
+	for id := range lockedAccounts {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
 // LockAccount пытается захватить мьютекс для указанного аккаунта.
-// Если аккаунт уже используется, возвращается ошибка.
-// В журнал записывается информация о попытке, успешной блокировке
-// и отказе в случае занятости.
+// Если аккаунт уже используется, возвращается ошибка. Дополнительно
+// выводится список заблокированных аккаунтов для упрощения диагностики.
 func LockAccount(accountID int) error {
 	log.Printf("[MUTEX] попытка блокировки аккаунта %d", accountID)
 
@@ -27,22 +37,32 @@ func LockAccount(accountID int) error {
 	globalMu.Unlock()
 
 	if !lock.TryLock() {
-		log.Printf("[MUTEX] аккаунт %d занят", accountID)
+		globalMu.Lock()
+		current := lockedIDs()
+		globalMu.Unlock()
+		log.Printf("[MUTEX] аккаунт %d занят; заблокированы: %v", accountID, current)
 		return fmt.Errorf("аккаунт %d уже используется", accountID)
 	}
 
-	log.Printf("[MUTEX] аккаунт %d заблокирован", accountID)
+	globalMu.Lock()
+	lockedAccounts[accountID] = struct{}{}
+	current := lockedIDs()
+	globalMu.Unlock()
+
+	log.Printf("[MUTEX] аккаунт %d заблокирован; заблокированы: %v", accountID, current)
 	return nil
 }
 
 // UnlockAccount освобождает мьютекс для указанного аккаунта
-// и записывает это событие в журнал.
+// и выводит актуальный список заблокированных аккаунтов.
 func UnlockAccount(accountID int) {
 	globalMu.Lock()
 	lock := accountLocks[accountID]
+	delete(lockedAccounts, accountID)
+	current := lockedIDs()
 	globalMu.Unlock()
 	if lock != nil {
 		lock.Unlock()
-		log.Printf("[MUTEX] аккаунт %d разблокирован", accountID)
+		log.Printf("[MUTEX] аккаунт %d разблокирован; заблокированы: %v", accountID, current)
 	}
 }


### PR DESCRIPTION
## Summary
- track locked accounts and log them on lock/unlock
- add debug logs for free/busy monitoring accounts and processing progress

## Testing
- `go test ./...` *(fails: command hung, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68bb56945aa483338cdd11ae07c68788