### PR TITLE
Allow duplicate channel URLs

### DIFF
--- a/migrations/2025-09-07-0100_allow_duplicate_channels.sql
+++ b/migrations/2025-09-07-0100_allow_duplicate_channels.sql
@@ -1,0 +1,5 @@
+-- Убираем ограничение уникальности ссылок каналов.
+ALTER TABLE channels DROP CONSTRAINT IF EXISTS channels_pkey;
+
+-- Добавляем суррогатный первичный ключ.
+ALTER TABLE channels ADD COLUMN id BIGSERIAL PRIMARY KEY;


### PR DESCRIPTION
## Summary
- drop unique constraint from `channels.url`
- stop deduplicating URLs when saving categories

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb5c9349b48333b01cf58d829b3786