### PR TITLE
fix: allow duplicate channels

### DIFF
--- a/migrations/2025-09-07-0100_allow_duplicate_channels.sql
+++ b/migrations/2025-09-07-0100_allow_duplicate_channels.sql
@@ -1,5 +1,25 @@
--- Убираем ограничение уникальности ссылок каналов.
-ALTER TABLE channels DROP CONSTRAINT IF EXISTS channels_pkey;
+-- Разрешаем дублирование ссылок каналов, заменяя первичный ключ.
+DO $$
+DECLARE
+    pk_name TEXT;
+BEGIN
+    -- Ищем имя текущего первичного ключа.
+    SELECT conname INTO pk_name
+    FROM pg_constraint
+    WHERE conrelid = 'channels'::regclass
+      AND contype = 'p';
 
--- Добавляем суррогатный первичный ключ.
-ALTER TABLE channels ADD COLUMN id BIGSERIAL PRIMARY KEY;
+    -- Удаляем найденный первичный ключ, если он существует.
+    IF pk_name IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE channels DROP CONSTRAINT %I', pk_name);
+    END IF;
+END $$;
+
+-- Добавляем суррогатный идентификатор.
+ALTER TABLE channels
+    ADD COLUMN IF NOT EXISTS id BIGSERIAL;
+
+-- Устанавливаем `id` в качестве первичного ключа.
+ALTER TABLE channels
+    ADD CONSTRAINT IF NOT EXISTS channels_pkey PRIMARY KEY (id);
+


### PR DESCRIPTION
## Summary
- remove existing primary key from `channels` via dynamic PL/pgSQL
- introduce surrogate `id` column and set it as the new primary key

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb5f7caa6883338ebb6862d7ae3f1b