### PR TITLE
Добавить суточные показатели реакций и комментариев в статистику

### DIFF
--- a/migrations/2025-09-07-0300_add_comment_reaction_all_statistics.sql
+++ b/migrations/2025-09-07-0300_add_comment_reaction_all_statistics.sql
@@ -1,0 +1,54 @@
+-- Добавление полей comment_all и reaction_all в таблицу statistics
+ALTER TABLE statistics
+    ADD COLUMN comment_all INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN reaction_all INTEGER NOT NULL DEFAULT 0;
+
+-- Обновление функции collect_statistics с учётом новых полей
+CREATE OR REPLACE FUNCTION collect_statistics() RETURNS VOID AS $$
+DECLARE
+    moscow_now   TIMESTAMPTZ := timezone('Europe/Moscow', now());
+    day_start    TIMESTAMPTZ;
+    day_end      TIMESTAMPTZ;
+    total_acc    INTEGER;
+    comment_cnt  INTEGER;
+    reaction_cnt INTEGER;
+    flood_cnt    INTEGER;
+BEGIN
+    day_start := date_trunc('day', moscow_now);
+    day_end   := day_start + interval '1 day';
+
+    SELECT COUNT(*) INTO total_acc
+    FROM accounts
+    WHERE is_authorized;
+
+    SELECT
+        COUNT(*) FILTER (WHERE activity_type = 'comment') AS comments,
+        COUNT(*) FILTER (WHERE activity_type = 'reaction') AS reactions
+    INTO comment_cnt, reaction_cnt
+    FROM activity
+    WHERE date_time >= day_start AT TIME ZONE 'UTC'
+      AND date_time <  day_end   AT TIME ZONE 'UTC';
+
+    SELECT COUNT(DISTINCT id) INTO flood_cnt
+    FROM accounts
+    WHERE floodwait_until > now();
+
+    INSERT INTO statistics (stat_date, comment_mean, reaction_mean, comment_all, reaction_all, account_floodban, account_all)
+    VALUES (
+        moscow_now::date,
+        COALESCE(comment_cnt::DOUBLE PRECISION / NULLIF(total_acc, 0), 0),
+        COALESCE(reaction_cnt::DOUBLE PRECISION / NULLIF(total_acc, 0), 0),
+        comment_cnt,
+        reaction_cnt,
+        flood_cnt,
+        total_acc
+    )
+    ON CONFLICT (stat_date) DO UPDATE
+        SET comment_mean   = EXCLUDED.comment_mean,
+            reaction_mean  = EXCLUDED.reaction_mean,
+            comment_all    = EXCLUDED.comment_all,
+            reaction_all   = EXCLUDED.reaction_all,
+            account_floodban = EXCLUDED.account_floodban,
+            account_all      = EXCLUDED.account_all;
+END;
+$$ LANGUAGE plpgsql;

--- a/models/statistics.go
+++ b/models/statistics.go
@@ -8,6 +8,8 @@ type Statistics struct {
 	Date            time.Time `json:"date"`             // Дата, за которую собрана статистика
 	CommentMean     float64   `json:"comment_mean"`     // Среднее количество комментариев на аккаунт
 	ReactionMean    float64   `json:"reaction_mean"`    // Среднее количество реакций на аккаунт
+	CommentAll      int       `json:"comment_all"`      // Общее количество комментариев за сутки
+	ReactionAll     int       `json:"reaction_all"`     // Общее количество реакций за сутки
 	AccountFloodBan int       `json:"account_floodban"` // Количество аккаунтов во флуд-бане
 	AccountAll      int       `json:"account_all"`      // Всего авторизованных аккаунтов
 }

--- a/pkg/telegram/statistics/statistics.go
+++ b/pkg/telegram/statistics/statistics.go
@@ -28,20 +28,18 @@ func Calculate(db *storage.DB) (*models.Statistics, error) {
 	}
 
 	// Общее количество комментариев за текущие сутки
-	var commentCount int
 	if err := db.Conn.QueryRow(
 		"SELECT COUNT(*) FROM activity WHERE activity_type = 'comment' AND date_time >= $1 AND date_time < $2",
 		dayStart.UTC(), dayEnd.UTC(),
-	).Scan(&commentCount); err != nil {
+	).Scan(&stat.CommentAll); err != nil {
 		return nil, err
 	}
 
 	// Общее количество реакций за текущие сутки
-	var reactionCount int
 	if err := db.Conn.QueryRow(
 		"SELECT COUNT(*) FROM activity WHERE activity_type = 'reaction' AND date_time >= $1 AND date_time < $2",
 		dayStart.UTC(), dayEnd.UTC(),
-	).Scan(&reactionCount); err != nil {
+	).Scan(&stat.ReactionAll); err != nil {
 		return nil, err
 	}
 
@@ -52,16 +50,16 @@ func Calculate(db *storage.DB) (*models.Statistics, error) {
 
 	// Расчёт средних значений
 	if stat.AccountAll > 0 {
-		stat.CommentMean = float64(commentCount) / float64(stat.AccountAll)
-		stat.ReactionMean = float64(reactionCount) / float64(stat.AccountAll)
+		stat.CommentMean = float64(stat.CommentAll) / float64(stat.AccountAll)
+		stat.ReactionMean = float64(stat.ReactionAll) / float64(stat.AccountAll)
 	}
 
 	// Сохраняем или обновляем запись в таблице statistics для текущей даты
 	err = db.Conn.QueryRow(
-		"INSERT INTO statistics (stat_date, comment_mean, reaction_mean, account_floodban, account_all) VALUES ($1, $2, $3, $4, $5) "+
-			"ON CONFLICT (stat_date) DO UPDATE SET comment_mean = EXCLUDED.comment_mean, reaction_mean = EXCLUDED.reaction_mean, account_floodban = EXCLUDED.account_floodban, account_all = EXCLUDED.account_all "+
+		"INSERT INTO statistics (stat_date, comment_mean, reaction_mean, comment_all, reaction_all, account_floodban, account_all) VALUES ($1, $2, $3, $4, $5, $6, $7) "+
+			"ON CONFLICT (stat_date) DO UPDATE SET comment_mean = EXCLUDED.comment_mean, reaction_mean = EXCLUDED.reaction_mean, comment_all = EXCLUDED.comment_all, reaction_all = EXCLUDED.reaction_all, account_floodban = EXCLUDED.account_floodban, account_all = EXCLUDED.account_all "+
 			"RETURNING id, stat_date",
-		stat.Date, stat.CommentMean, stat.ReactionMean, stat.AccountFloodBan, stat.AccountAll,
+		stat.Date, stat.CommentMean, stat.ReactionMean, stat.CommentAll, stat.ReactionAll, stat.AccountFloodBan, stat.AccountAll,
 	).Scan(&stat.ID, &stat.Date)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- добавить в таблицу statistics поля comment_all и reaction_all
- учитывать новые поля при расчёте и сохранении статистики
- обновить функцию collect_statistics

## Testing
- `go test ./...` *(остановлено: нет вывода)*

------
https://chatgpt.com/codex/tasks/task_e_68bed8d7ed08833391e11587412e68f7