### PR TITLE
Добавить суточные показатели реакций и комментариев в статистику

### DIFF
--- a/internal/comments/handler.go
+++ b/internal/comments/handler.go
@@ -7,6 +7,7 @@ import (
 	"atg_go/models"
 	"atg_go/pkg/storage"
 	"atg_go/pkg/telegram"
+	stats "atg_go/pkg/telegram/statistics"
 	"log"
 	"net/http"
 
@@ -101,6 +102,11 @@ func (h *CommentHandler) SendComment(c *gin.Context) {
 	if err != nil {
 		// Процессор уже отправил ответ клиенту, поэтому просто прекращаем обработку.
 		return
+	}
+
+	// Фиксируем успешные комментарии в статистике
+	if err := stats.IncrementComment(h.DB, successCount); err != nil {
+		log.Printf("[HANDLER ERROR] не удалось обновить статистику: %v", err)
 	}
 
 	// Итоговый ответ (канал убран, т.к. каждый повтор выбирался свой)

--- a/internal/reaction/handler.go
+++ b/internal/reaction/handler.go
@@ -7,6 +7,7 @@ import (
 	"atg_go/models"
 	"atg_go/pkg/storage"
 	"atg_go/pkg/telegram"
+	stats "atg_go/pkg/telegram/statistics"
 	"log"
 	"net/http"
 
@@ -87,6 +88,11 @@ func (h *ReactionHandler) SendReaction(c *gin.Context) {
 	if err != nil {
 		// Ответ уже отправлен внутри обработчика, поэтому завершаем выполнение.
 		return
+	}
+
+	// Фиксируем успешные реакции в статистике
+	if err := stats.IncrementReaction(h.DB, successCount); err != nil {
+		log.Printf("[HANDLER ERROR] не удалось обновить статистику: %v", err)
 	}
 
 	result := gin.H{

--- a/migrations/2025-09-07-0400_add_comment_reaction_all_statistics.sql
+++ b/migrations/2025-09-07-0400_add_comment_reaction_all_statistics.sql
@@ -1,0 +1,7 @@
+-- Добавление полей comment_all и reaction_all в таблицу statistics
+ALTER TABLE statistics
+    ADD COLUMN comment_all INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN reaction_all INTEGER NOT NULL DEFAULT 0;
+
+-- Функция collect_statistics больше не используется
+DROP FUNCTION IF EXISTS collect_statistics();

--- a/models/statistics.go
+++ b/models/statistics.go
@@ -8,6 +8,8 @@ type Statistics struct {
 	Date            time.Time `json:"date"`             // Дата, за которую собрана статистика
 	CommentMean     float64   `json:"comment_mean"`     // Среднее количество комментариев на аккаунт
 	ReactionMean    float64   `json:"reaction_mean"`    // Среднее количество реакций на аккаунт
+	CommentAll      int       `json:"comment_all"`      // Общее количество комментариев за сутки
+	ReactionAll     int       `json:"reaction_all"`     // Общее количество реакций за сутки
 	AccountFloodBan int       `json:"account_floodban"` // Количество аккаунтов во флуд-бане
 	AccountAll      int       `json:"account_all"`      // Всего авторизованных аккаунтов
 }

--- a/pkg/telegram/statistics/increment.go
+++ b/pkg/telegram/statistics/increment.go
@@ -1,0 +1,39 @@
+package statistics
+
+import (
+	"atg_go/pkg/storage"
+	"time"
+)
+
+// IncrementReaction увеличивает счётчик реакций за текущие сутки на указанное количество.
+func IncrementReaction(db *storage.DB, count int) error {
+	return increment(db, 0, count)
+}
+
+// IncrementComment увеличивает счётчик комментариев за текущие сутки на указанное количество.
+func IncrementComment(db *storage.DB, count int) error {
+	return increment(db, count, 0)
+}
+
+// increment выполняет обновление записи statistics, добавляя переданные значения.
+func increment(db *storage.DB, commentDelta, reactionDelta int) error {
+	if commentDelta == 0 && reactionDelta == 0 {
+		return nil
+	}
+
+	loc, err := time.LoadLocation("Europe/Moscow")
+	if err != nil {
+		return err
+	}
+	dayStart := time.Now().In(loc).Truncate(24 * time.Hour)
+
+	_, err = db.Conn.Exec(
+		`INSERT INTO statistics (stat_date, comment_mean, reaction_mean, comment_all, reaction_all, account_floodban, account_all)
+                 VALUES ($1, 0, 0, $2, $3, 0, 0)
+                 ON CONFLICT (stat_date) DO UPDATE SET
+                    comment_all = statistics.comment_all + EXCLUDED.comment_all,
+                    reaction_all = statistics.reaction_all + EXCLUDED.reaction_all`,
+		dayStart, commentDelta, reactionDelta,
+	)
+	return err
+}

--- a/pkg/telegram/statistics/statistics.go
+++ b/pkg/telegram/statistics/statistics.go
@@ -3,66 +3,61 @@ package statistics
 import (
 	"atg_go/models"
 	"atg_go/pkg/storage"
+	"database/sql"
 	"time"
 )
 
-// Calculate вычисляет статистику по базе и сохраняет её в таблицу statistics.
+// Calculate обновляет средние показатели за текущие сутки и сохраняет их в таблицу statistics.
 func Calculate(db *storage.DB) (*models.Statistics, error) {
 	var stat models.Statistics
 
-	// Загружаем часовой пояс Москвы
+	// Определяем начало суток по московскому времени
 	loc, err := time.LoadLocation("Europe/Moscow")
 	if err != nil {
 		return nil, err
 	}
-
-	// Определяем начало и конец текущих суток по московскому времени
-	now := time.Now().In(loc)
-	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
-	dayEnd := dayStart.Add(24 * time.Hour)
+	dayStart := time.Now().In(loc).Truncate(24 * time.Hour)
 	stat.Date = dayStart
+
+	// Получаем существующую запись или создаём новую
+	err = db.Conn.QueryRow(
+		"SELECT id, comment_all, reaction_all FROM statistics WHERE stat_date = $1",
+		dayStart,
+	).Scan(&stat.ID, &stat.CommentAll, &stat.ReactionAll)
+	if err == sql.ErrNoRows {
+		// Создаём запись с нулевыми значениями
+		err = db.Conn.QueryRow(
+			"INSERT INTO statistics (stat_date, comment_mean, reaction_mean, comment_all, reaction_all, account_floodban, account_all) VALUES ($1, 0, 0, 0, 0, 0, 0) RETURNING id",
+			dayStart,
+		).Scan(&stat.ID)
+		if err != nil {
+			return nil, err
+		}
+	} else if err != nil {
+		return nil, err
+	}
 
 	// Количество авторизованных аккаунтов
 	if err := db.Conn.QueryRow("SELECT COUNT(*) FROM accounts WHERE is_authorized = true").Scan(&stat.AccountAll); err != nil {
 		return nil, err
 	}
 
-	// Общее количество комментариев за текущие сутки
-	var commentCount int
-	if err := db.Conn.QueryRow(
-		"SELECT COUNT(*) FROM activity WHERE activity_type = 'comment' AND date_time >= $1 AND date_time < $2",
-		dayStart.UTC(), dayEnd.UTC(),
-	).Scan(&commentCount); err != nil {
-		return nil, err
-	}
-
-	// Общее количество реакций за текущие сутки
-	var reactionCount int
-	if err := db.Conn.QueryRow(
-		"SELECT COUNT(*) FROM activity WHERE activity_type = 'reaction' AND date_time >= $1 AND date_time < $2",
-		dayStart.UTC(), dayEnd.UTC(),
-	).Scan(&reactionCount); err != nil {
-		return nil, err
-	}
-
-	// Количество аккаунтов, находящихся во флуд-бане
+	// Количество аккаунтов во флуд-бане
 	if err := db.Conn.QueryRow("SELECT COUNT(*) FROM accounts WHERE floodwait_until IS NOT NULL AND floodwait_until > NOW()").Scan(&stat.AccountFloodBan); err != nil {
 		return nil, err
 	}
 
 	// Расчёт средних значений
 	if stat.AccountAll > 0 {
-		stat.CommentMean = float64(commentCount) / float64(stat.AccountAll)
-		stat.ReactionMean = float64(reactionCount) / float64(stat.AccountAll)
+		stat.CommentMean = float64(stat.CommentAll) / float64(stat.AccountAll)
+		stat.ReactionMean = float64(stat.ReactionAll) / float64(stat.AccountAll)
 	}
 
-	// Сохраняем или обновляем запись в таблице statistics для текущей даты
-	err = db.Conn.QueryRow(
-		"INSERT INTO statistics (stat_date, comment_mean, reaction_mean, account_floodban, account_all) VALUES ($1, $2, $3, $4, $5) "+
-			"ON CONFLICT (stat_date) DO UPDATE SET comment_mean = EXCLUDED.comment_mean, reaction_mean = EXCLUDED.reaction_mean, account_floodban = EXCLUDED.account_floodban, account_all = EXCLUDED.account_all "+
-			"RETURNING id, stat_date",
-		stat.Date, stat.CommentMean, stat.ReactionMean, stat.AccountFloodBan, stat.AccountAll,
-	).Scan(&stat.ID, &stat.Date)
+	// Сохраняем обновлённые данные
+	_, err = db.Conn.Exec(
+		"UPDATE statistics SET comment_mean = $1, reaction_mean = $2, account_floodban = $3, account_all = $4 WHERE stat_date = $5",
+		stat.CommentMean, stat.ReactionMean, stat.AccountFloodBan, stat.AccountAll, stat.Date,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- расширить таблицу statistics полями comment_all и reaction_all
- учитывать успешные реакции и комментарии в go-коде
- рассчитывать средние значения из накопленных счётчиков

## Testing
- `go test ./...` *(остановлено: нет вывода)*

------
https://chatgpt.com/codex/tasks/task_e_68bed8d7ed08833391e11587412e68f7