### PR TITLE
Rename session disconnect module and schedule daily run

### DIFF
--- a/internal/module/accounts_sessions_disconnect/handler.go
+++ b/internal/module/accounts_sessions_disconnect/handler.go
@@ -1,4 +1,4 @@
-package active_sessions_disconnect
+package accounts_sessions_disconnect
 
 import (
 	"log"
@@ -6,7 +6,7 @@ import (
 
 	"atg_go/internal/httputil"
 	"atg_go/pkg/storage"
-	telegrammodule "atg_go/pkg/telegram/module/active_sessions_disconnect"
+	telegrammodule "atg_go/pkg/telegram/module/accounts_sessions_disconnect"
 
 	"github.com/gin-gonic/gin"
 )
@@ -67,7 +67,7 @@ func (h *Handler) Disconnect(c *gin.Context) {
 	res, err := telegrammodule.DisconnectSuspiciousSessions(h.DB, minDelay, maxDelay)
 	if err != nil {
 		// Логируем ошибку, чтобы понять, где произошёл сбой
-		log.Printf("[ACTIVE SESSIONS DISCONNECT] ошибка выполнения: %v", err)
+		log.Printf("[ACCOUNTS SESSIONS DISCONNECT] ошибка выполнения: %v", err)
 		httputil.RespondError(c, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/module/accounts_sessions_disconnect/routes.go
+++ b/internal/module/accounts_sessions_disconnect/routes.go
@@ -1,4 +1,4 @@
-package active_sessions_disconnect
+package accounts_sessions_disconnect
 
 import (
 	"atg_go/pkg/storage"
@@ -6,10 +6,13 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// SetupRoutes регистрирует маршруты для работы с активными сессиями.
+// SetupRoutes регистрирует маршруты для работы с активными сессиями
+// и запускает фоновые отключения.
 func SetupRoutes(r *gin.RouterGroup, db *storage.DB) {
 	handler := NewHandler(db)
 	// Используем POST, чтобы соответствовать соглашению модульных маршрутов.
 	r.POST("", handler.Disconnect)
 	r.POST("/info", handler.Info)
+	// Запускаем фоновые отключения в 02:00 и 11:00 по МСК.
+	startBackgroundDisconnect(db)
 }

--- a/internal/module/accounts_sessions_disconnect/scheduler.go
+++ b/internal/module/accounts_sessions_disconnect/scheduler.go
@@ -1,0 +1,38 @@
+package accounts_sessions_disconnect
+
+import (
+	"log"
+	"time"
+
+	"atg_go/pkg/storage"
+	telegrammodule "atg_go/pkg/telegram/module/accounts_sessions_disconnect"
+)
+
+// startBackgroundDisconnect запускает бесконечный цикл, который
+// выполняет отключение сессий каждый день в 02:00 и 11:00 по МСК.
+func startBackgroundDisconnect(db *storage.DB) {
+	go func() {
+		for {
+			now := time.Now()
+			// Рассчитываем ближайшее целевое время.
+			year, month, day := now.Date()
+			loc := now.Location()
+			t02 := time.Date(year, month, day, 2, 0, 0, 0, loc)
+			t11 := time.Date(year, month, day, 11, 0, 0, 0, loc)
+			var next time.Time
+			switch {
+			case now.Before(t02):
+				next = t02
+			case now.Before(t11):
+				next = t11
+			default:
+				next = t02.AddDate(0, 0, 1)
+			}
+			time.Sleep(next.Sub(now))
+			if _, err := telegrammodule.DisconnectSuspiciousSessions(db, 0, 0); err != nil {
+				// Фиксируем ошибку, чтобы отслеживать проблемы
+				log.Printf("[ACCOUNTS SESSIONS DISCONNECT] ошибка фонового отключения: %v", err)
+			}
+		}
+	}()
+}

--- a/internal/module/dispatcher.go
+++ b/internal/module/dispatcher.go
@@ -17,12 +17,12 @@ import (
 // Помимо activity_request ожидает параметры запуска для разных типов действий.
 func (h *Handler) DispatcherActivity(c *gin.Context) {
 	var req struct {
-		DaysNumber                       int                                             `json:"days_number" binding:"required"`
-		ActivityRequest                  []telegrammodule.ActivityRequest                `json:"activity_request" binding:"required"`
-		ActivityComment                  telegrammodule.ActivitySettings                 `json:"activity_comment" binding:"required"`
-		ActivityReaction                 telegrammodule.ActivitySettings                 `json:"activity_reaction" binding:"required"`
-		ActivityAccountsUnsubscribe      telegrammodule.UnsubscribeSettings              `json:"activity_accounts_unsubscribe" binding:"required"`
-		ActivityActiveSessionsDisconnect telegrammodule.ActiveSessionsDisconnectSettings `json:"activity_active_sessions_disconnect" binding:"required"`
+		DaysNumber                         int                                               `json:"days_number" binding:"required"`
+		ActivityRequest                    []telegrammodule.ActivityRequest                  `json:"activity_request" binding:"required"`
+		ActivityComment                    telegrammodule.ActivitySettings                   `json:"activity_comment" binding:"required"`
+		ActivityReaction                   telegrammodule.ActivitySettings                   `json:"activity_reaction" binding:"required"`
+		ActivityAccountsUnsubscribe        telegrammodule.UnsubscribeSettings                `json:"activity_accounts_unsubscribe" binding:"required"`
+		ActivityAccountsSessionsDisconnect telegrammodule.AccountsSessionsDisconnectSettings `json:"activity_accounts_sessions_disconnect" binding:"required"`
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -45,7 +45,7 @@ func (h *Handler) DispatcherActivity(c *gin.Context) {
 			delete(h.tasks, taskID)
 			h.mu.Unlock()
 		}()
-		telegrammodule.ModF_DispatcherActivity(ctx, req.DaysNumber, req.ActivityRequest, req.ActivityComment, req.ActivityReaction, req.ActivityAccountsUnsubscribe, req.ActivityActiveSessionsDisconnect)
+		telegrammodule.ModF_DispatcherActivity(ctx, req.DaysNumber, req.ActivityRequest, req.ActivityComment, req.ActivityReaction, req.ActivityAccountsUnsubscribe, req.ActivityAccountsSessionsDisconnect)
 	}(id)
 
 	c.JSON(http.StatusOK, gin.H{"status": "запущено", "task_id": id})

--- a/internal/module/routes.go
+++ b/internal/module/routes.go
@@ -2,7 +2,7 @@ package module
 
 import (
 	authcheck "atg_go/internal/module/account_auth_check"
-	activesessions "atg_go/internal/module/active_sessions_disconnect"
+	accountssessions "atg_go/internal/module/accounts_sessions_disconnect"
 	"atg_go/pkg/storage"
 
 	"github.com/gin-gonic/gin"
@@ -17,5 +17,5 @@ func SetupRoutes(r *gin.RouterGroup, db *storage.DB) {
 	r.POST("/order/link_updat", handler.OrderLinkUpdate)
 	r.POST("/channel_duplicate/:id/post_count_day", handler.UpdateChannelDuplicateTimes)
 	authcheck.SetupRoutes(r.Group("/account_auth_check"), db)
-	activesessions.SetupRoutes(r.Group("/active_sessions_disconnect"), db)
+	accountssessions.SetupRoutes(r.Group("/accounts_sessions_disconnect"), db)
 }

--- a/pkg/telegram/module/accounts_sessions_disconnect/check.go
+++ b/pkg/telegram/module/accounts_sessions_disconnect/check.go
@@ -1,4 +1,4 @@
-package active_sessions_disconnect
+package accounts_sessions_disconnect
 
 import (
 	"context"
@@ -23,7 +23,7 @@ func CheckAccountsState(db *storage.DB) ([]string, error) {
 	for _, acc := range accounts {
 		client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, nil)
 		if err != nil {
-			log.Printf("[ACTIVE SESSIONS] аккаунт %d (%s): ошибка инициализации: %v", acc.ID, acc.Phone, err)
+			log.Printf("[ACCOUNTS SESSIONS] аккаунт %d (%s): ошибка инициализации: %v", acc.ID, acc.Phone, err)
 			lost = append(lost, acc.Phone)
 			continue
 		}
@@ -35,7 +35,7 @@ func CheckAccountsState(db *storage.DB) ([]string, error) {
 			return err
 		})
 		if err != nil {
-			log.Printf("[ACTIVE SESSIONS] аккаунт %d (%s): потерян доступ: %v", acc.ID, acc.Phone, err)
+			log.Printf("[ACCOUNTS SESSIONS] аккаунт %d (%s): потерян доступ: %v", acc.ID, acc.Phone, err)
 			lost = append(lost, acc.Phone)
 		}
 	}

--- a/pkg/telegram/module/accounts_sessions_disconnect/disconnect.go
+++ b/pkg/telegram/module/accounts_sessions_disconnect/disconnect.go
@@ -1,4 +1,4 @@
-package active_sessions_disconnect
+package accounts_sessions_disconnect
 
 import (
 	"context"
@@ -29,7 +29,7 @@ func DisconnectSuspiciousSessions(db *storage.DB, minDelay, maxDelay int) (map[s
 	accounts, err := db.GetAuthorizedAccounts()
 	if err != nil {
 		// Логируем ошибку, чтобы быстрее найти проблемы с БД
-		log.Printf("[ACTIVE SESSIONS DISCONNECT] ошибка получения аккаунтов: %v", err)
+		log.Printf("[ACCOUNTS SESSIONS DISCONNECT] ошибка получения аккаунтов: %v", err)
 		return nil, err
 	}
 
@@ -53,7 +53,7 @@ func DisconnectSuspiciousSessions(db *storage.DB, minDelay, maxDelay int) (map[s
 		client, err := module.Modf_AccountInitialization(acc.ApiID, acc.ApiHash, acc.Phone, acc.Proxy, nil, db.Conn, acc.ID, nil)
 		if err != nil {
 			// Не прерываем работу из-за одного аккаунта, чтобы обработать остальные
-			log.Printf("[ACTIVE SESSIONS DISCONNECT] аккаунт %s: ошибка инициализации: %v", acc.Phone, err)
+			log.Printf("[ACCOUNTS SESSIONS DISCONNECT] аккаунт %s: ошибка инициализации: %v", acc.Phone, err)
 			continue
 		}
 
@@ -77,17 +77,17 @@ func DisconnectSuspiciousSessions(db *storage.DB, minDelay, maxDelay int) (map[s
 					// Фиксируем проблему в таблице Sos, чтобы вовремя заметить сбой.
 					msg := fmt.Sprintf("аккаунт %d (%s), устройство %s: %v", acc.ID, acc.Phone, a.DeviceModel, err)
 					if saveErr := db.SaveSos(msg); saveErr != nil {
-						log.Printf("[ACTIVE SESSIONS DISCONNECT] ошибка записи в Sos: %v", saveErr)
+						log.Printf("[ACCOUNTS SESSIONS DISCONNECT] ошибка записи в Sos: %v", saveErr)
 					}
-					log.Printf("[ACTIVE SESSIONS DISCONNECT] аккаунт %s: не удалось отключить %s: %v", acc.Phone, a.DeviceModel, err)
+					log.Printf("[ACCOUNTS SESSIONS DISCONNECT] аккаунт %s: не удалось отключить %s: %v", acc.Phone, a.DeviceModel, err)
 					continue
 				}
-				log.Printf("[ACTIVE SESSIONS DISCONNECT] аккаунт %s: отключено устройство %s", acc.Phone, a.DeviceModel)
+				log.Printf("[ACCOUNTS SESSIONS DISCONNECT] аккаунт %s: отключено устройство %s", acc.Phone, a.DeviceModel)
 				result[acc.Phone] = append(result[acc.Phone], a.DeviceModel)
 			}
 			return nil
 		}); err != nil {
-			log.Printf("[ACTIVE SESSIONS DISCONNECT] аккаунт %s: ошибка обработки: %v", acc.Phone, err)
+			log.Printf("[ACCOUNTS SESSIONS DISCONNECT] аккаунт %s: ошибка обработки: %v", acc.Phone, err)
 		}
 	}
 

--- a/pkg/telegram/module/dispatcher_activity.go
+++ b/pkg/telegram/module/dispatcher_activity.go
@@ -33,8 +33,8 @@ type UnsubscribeSettings struct {
 	DispatcherStart string `json:"dispatcher_start"`
 }
 
-// ActiveSessionsDisconnectSettings задаёт время отключения активных сессий.
-type ActiveSessionsDisconnectSettings struct {
+// AccountsSessionsDisconnectSettings задаёт время отключения активных сессий.
+type AccountsSessionsDisconnectSettings struct {
 	DispatcherStart string `json:"dispatcher_start"`
 }
 
@@ -125,7 +125,7 @@ func runActivityInPeriod(ctx context.Context, base time.Time, loc *time.Location
 
 // ModF_DispatcherActivity выполняет запросы активности в течение
 // заданного количества суток и реагирует на отмену контекста.
-func ModF_DispatcherActivity(ctx context.Context, daysNumber int, activities []ActivityRequest, commentCfg, reactionCfg ActivitySettings, unsubscribeCfg UnsubscribeSettings, disconnectCfg ActiveSessionsDisconnectSettings) {
+func ModF_DispatcherActivity(ctx context.Context, daysNumber int, activities []ActivityRequest, commentCfg, reactionCfg ActivitySettings, unsubscribeCfg UnsubscribeSettings, disconnectCfg AccountsSessionsDisconnectSettings) {
 	rand.Seed(time.Now().UnixNano())
 
 	// Загружаем часовую зону Москвы и фиксируем текущее время в ней,
@@ -177,7 +177,7 @@ func ModF_DispatcherActivity(ctx context.Context, daysNumber int, activities []A
 					defer wg.Done()
 					runAtDispatcherStart(ctx, start, loc, act, unsubscribeCfg.DispatcherStart, offset)
 				}(act, day)
-			case strings.Contains(act.URL, "active_sessions_disconnect"):
+			case strings.Contains(act.URL, "accounts_sessions_disconnect"):
 				if disconnectCfg.DispatcherStart == "" {
 					continue
 				}


### PR DESCRIPTION
## Summary
- rename active sessions disconnect to accounts sessions disconnect
- trigger session disconnect at 02:00 and 11:00 in background

## Testing
- `go test ./...` *(fails: command hung)*
- `go build ./...` *(fails: command hung)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d5aaa1608333beb9338de732f497